### PR TITLE
feat: reviewer scoring form

### DIFF
--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -7,8 +7,7 @@ import Dropdown from '@/components/TanstackTable/Dropdown'
 import { upsertAdminScoring } from '@/lib/forms'
 import { FormPassbackState, NextActionEnum } from '@/lib/types'
 import { AlevelQualification, GCSEQualification } from '@prisma/client'
-import { FileTextIcon, IdCardIcon } from '@radix-ui/react-icons'
-import { Button, Callout, Flex, Heading, Popover, Text, TextField } from '@radix-ui/themes'
+import { Button, Callout, DataList, Flex, Heading, Text, TextField } from '@radix-ui/themes'
 import { format } from 'date-fns'
 import React, { FC, useState } from 'react'
 
@@ -37,11 +36,19 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
           {format(internalReview?.lastAdminEditOn, "dd/MM/yy 'at' HH:mm")}
         </Text>
       )}
-      <Callout.Root>
-        <Callout.Text size="3">
-          Applicant: {applicant.firstName} {applicant.surname}
-        </Callout.Text>
-        <Callout.Text size="3">UCAS number: {applicant.ucasNumber}</Callout.Text>
+      <Callout.Root className="my-5">
+        <DataList.Root>
+          <DataList.Item align="center">
+            <DataList.Label>Applicant:</DataList.Label>
+            <DataList.Value className="font-bold">
+              {applicant.firstName} {applicant.surname}
+            </DataList.Value>
+          </DataList.Item>
+          <DataList.Item align="center">
+            <DataList.Label>UCAS number:</DataList.Label>
+            <DataList.Value className="font-bold">{applicant.ucasNumber}</DataList.Value>
+          </DataList.Item>
+        </DataList.Root>
       </Callout.Root>
 
       <Flex direction="column" gap="2">

--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -7,7 +7,17 @@ import Dropdown from '@/components/TanstackTable/Dropdown'
 import { upsertAdminScoring } from '@/lib/forms'
 import { FormPassbackState, NextActionEnum } from '@/lib/types'
 import { AlevelQualification, GCSEQualification } from '@prisma/client'
-import { Button, Callout, DataList, Flex, Heading, Text, TextField } from '@radix-ui/themes'
+import { FileTextIcon, IdCardIcon } from '@radix-ui/react-icons'
+import {
+  Button,
+  Callout,
+  DataList,
+  Flex,
+  Heading,
+  Popover,
+  Text,
+  TextField
+} from '@radix-ui/themes'
 import { format } from 'date-fns'
 import React, { FC, useState } from 'react'
 

--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -144,7 +144,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
           </LabelText>
         </Flex>
 
-        <LabelText label="Motivation Assessments">
+        <LabelText label="Motivation Assessments (optional)">
           <TextField.Root
             id="motivationAdminScore"
             name="motivationAdminScore"
@@ -156,7 +156,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
           />
         </LabelText>
 
-        <LabelText label="Extracurricular Assessments">
+        <LabelText label="Extracurricular Assessments (optional)">
           <TextField.Root
             id="extracurricularAdminScore"
             name="extracurricularAdminScore"
@@ -168,7 +168,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
           />
         </LabelText>
 
-        <LabelText label="Exam Comments">
+        <LabelText label="Exam Comments (optional)">
           <TextField.Root
             id="examComments"
             name="examComments"

--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -31,6 +31,8 @@ interface AdminScoringFormProps {
   data: ApplicationRow
 }
 
+const ICON_SIZE = 16
+
 const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
   const { applicant, internalReview } = data
   const [gcseQualification, setGcseQualification] = useState(data.gcseQualification?.toString())
@@ -39,7 +41,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
   )
 
   return (
-    <Flex direction="column" gap="2">
+    <Flex direction="column" gap="3">
       {internalReview?.lastAdminEditOn && internalReview?.lastAdminEditBy && (
         <Text size="2" className="italic text-gray-500">
           Last edited by {internalReview.lastAdminEditBy} on{' '}
@@ -67,7 +69,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
             <Popover.Root>
               <Popover.Trigger>
                 <Button type="button" variant="soft" color="yellow">
-                  <IdCardIcon width={16} height={16} />
+                  <IdCardIcon width={ICON_SIZE} height={ICON_SIZE} />
                   Extenuating circumstances
                 </Button>
               </Popover.Trigger>
@@ -83,7 +85,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
             <Popover.Root>
               <Popover.Trigger>
                 <Button type="button" variant="soft" color="yellow">
-                  <FileTextIcon width={16} height={16} />
+                  <FileTextIcon width={ICON_SIZE} height={ICON_SIZE} />
                   Academic eligibility notes
                 </Button>
               </Popover.Trigger>

--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -32,8 +32,8 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
     <Flex direction="column" gap="2">
       {internalReview?.lastAdminEditOn && internalReview?.lastAdminEditBy && (
         <Text size="2" className="italic text-gray-500">
-          Last edited by {internalReview?.lastAdminEditBy} on{' '}
-          {format(internalReview?.lastAdminEditOn, "dd/MM/yy 'at' HH:mm")}
+          Last edited by {internalReview.lastAdminEditBy} on{' '}
+          {format(internalReview.lastAdminEditOn, "dd/MM/yy 'at' HH:mm")}
         </Text>
       )}
       <Callout.Root className="my-5">

--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -46,7 +46,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
           {format(internalReview.lastAdminEditOn, "dd/MM/yy 'at' HH:mm")}
         </Text>
       )}
-      <Callout.Root className="my-5">
+      <Callout.Root>
         <DataList.Root>
           <DataList.Item align="center">
             <DataList.Label>Applicant:</DataList.Label>

--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -7,7 +7,8 @@ import Dropdown from '@/components/TanstackTable/Dropdown'
 import { upsertAdminScoring } from '@/lib/forms'
 import { FormPassbackState, NextActionEnum } from '@/lib/types'
 import { AlevelQualification, GCSEQualification } from '@prisma/client'
-import { Button, Callout, Flex, Heading, Text, TextField } from '@radix-ui/themes'
+import { FileTextIcon, IdCardIcon } from '@radix-ui/react-icons'
+import { Button, Callout, Flex, Heading, Popover, Text, TextField } from '@radix-ui/themes'
 import { format } from 'date-fns'
 import React, { FC, useState } from 'react'
 
@@ -29,14 +30,14 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
   )
 
   return (
-    <>
+    <Flex direction="column" gap="2">
       {internalReview?.lastAdminEditOn && internalReview?.lastAdminEditBy && (
         <Text size="2" className="italic text-gray-500">
           Last edited by {internalReview?.lastAdminEditBy} on{' '}
           {format(internalReview?.lastAdminEditOn, "dd/MM/yy 'at' HH:mm")}
         </Text>
       )}
-      <Callout.Root className="my-5">
+      <Callout.Root>
         <Callout.Text size="3">
           Applicant: {applicant.firstName} {applicant.surname}
         </Callout.Text>
@@ -44,97 +45,131 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data }) => {
       </Callout.Root>
 
       <Flex direction="column" gap="2">
-        <Heading as="h3" size="2">
-          Age 16 exam
-        </Heading>
-        <LabelText label="Type" weight="regular">
-          <Dropdown
-            values={Object.keys(GCSEQualification)}
-            currentValue={gcseQualification}
-            onValueChange={setGcseQualification}
-            className="flex-grow"
-          />
-          <input name="gcseQualification" type="hidden" value={gcseQualification?.toString()} />
-        </LabelText>
+        <Flex direction="column" gap="2">
+          {data.extenuatingCircumstances && (
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button type="button" variant="soft" color="yellow">
+                  <IdCardIcon width={16} height={16} />
+                  Extenuating circumstances
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content className="bg-yellow-50">
+                <Text>{data.extenuatingCircumstances}</Text>
+              </Popover.Content>
+            </Popover.Root>
+          )}
+        </Flex>
 
-        <LabelText label="Score" weight="regular">
+        <Flex direction="column" gap="2">
+          {data.academicEligibilityNotes && (
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button type="button" variant="soft" color="yellow">
+                  <FileTextIcon width={16} height={16} />
+                  Academic eligibility notes
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content className="bg-yellow-50">
+                <Text>{data.academicEligibilityNotes}</Text>
+              </Popover.Content>
+            </Popover.Root>
+          )}
+        </Flex>
+
+        <Flex direction="column" gap="2">
+          <Heading as="h3" size="2">
+            Age 16 exam
+          </Heading>
+          <LabelText label="Type" weight="regular">
+            <Dropdown
+              values={Object.keys(GCSEQualification)}
+              currentValue={gcseQualification}
+              onValueChange={setGcseQualification}
+              className="flex-grow"
+            />
+            <input name="gcseQualification" type="hidden" value={gcseQualification} />
+          </LabelText>
+
+          <LabelText label="Score" weight="regular">
+            <TextField.Root
+              id="gcseQualificationScore"
+              name="gcseQualificationScore"
+              type="number"
+              min={0.0}
+              max={10.0}
+              step={0.1}
+              className="flex-grow"
+              disabled={!gcseQualification}
+              required={!!gcseQualification}
+              defaultValue={parseFloat(data?.gcseQualificationScore?.toString() ?? '')}
+            />
+          </LabelText>
+        </Flex>
+
+        <Flex direction="column" gap="2">
+          <Heading as="h3" size="2">
+            Age 18 exam
+          </Heading>
+          <LabelText label="Type" weight="regular">
+            <Dropdown
+              values={Object.keys(AlevelQualification)}
+              currentValue={aLevelQualification}
+              onValueChange={setALevelQualification}
+              className="flex-grow"
+            />
+            <input name="aLevelQualification" type="hidden" value={aLevelQualification} />
+          </LabelText>
+
+          <LabelText label="Score" weight="regular">
+            <TextField.Root
+              id="aLevelQualificationScore"
+              name="aLevelQualificationScore"
+              type="number"
+              min={0.0}
+              max={10.0}
+              step={0.1}
+              className="flex-grow"
+              disabled={!aLevelQualification}
+              required={!!aLevelQualification}
+              defaultValue={parseFloat(data?.aLevelQualificationScore?.toString() ?? '')}
+            />
+          </LabelText>
+        </Flex>
+
+        <LabelText label="Motivation Assessments">
           <TextField.Root
-            id="gcseQualificationScore"
-            name="gcseQualificationScore"
+            id="motivationAdminScore"
+            name="motivationAdminScore"
             type="number"
             min={0.0}
             max={10.0}
             step={0.1}
-            className="flex-grow"
-            disabled={!gcseQualification}
-            required={!!gcseQualification}
-            defaultValue={parseFloat(data?.gcseQualificationScore?.toString() ?? '')}
+            defaultValue={parseFloat(internalReview?.motivationAdminScore?.toString() ?? '')}
           />
         </LabelText>
-      </Flex>
 
-      <Flex direction="column" gap="2">
-        <Heading as="h3" size="2">
-          Age 18 exam
-        </Heading>
-        <LabelText label="Type" weight="regular">
-          <Dropdown
-            values={Object.keys(AlevelQualification)}
-            currentValue={aLevelQualification}
-            onValueChange={setALevelQualification}
-            className="flex-grow"
-          />
-          <input name="aLevelQualification" type="hidden" value={aLevelQualification?.toString()} />
-        </LabelText>
-
-        <LabelText label="Score" weight="regular">
+        <LabelText label="Extracurricular Assessments">
           <TextField.Root
-            id="aLevelQualificationScore"
-            name="aLevelQualificationScore"
+            id="extracurricularAdminScore"
+            name="extracurricularAdminScore"
             type="number"
             min={0.0}
             max={10.0}
             step={0.1}
-            className="flex-grow"
-            disabled={!aLevelQualification}
-            required={!!aLevelQualification}
-            defaultValue={parseFloat(data?.aLevelQualificationScore?.toString() ?? '')}
+            defaultValue={parseFloat(internalReview?.extracurricularAdminScore?.toString() ?? '')}
+          />
+        </LabelText>
+
+        <LabelText label="Exam Comments">
+          <TextField.Root
+            id="examComments"
+            name="examComments"
+            defaultValue={internalReview?.examComments ?? undefined}
           />
         </LabelText>
       </Flex>
-
-      <LabelText label="Motivation Assessments">
-        <TextField.Root
-          id="motivationAdminScore"
-          name="motivationAdminScore"
-          type="number"
-          min={0.0}
-          max={10.0}
-          step={0.1}
-          defaultValue={parseFloat(internalReview?.motivationAdminScore?.toString() ?? '')}
-        />
-      </LabelText>
-
-      <LabelText label="Extracurricular Assessments">
-        <TextField.Root
-          id="extracurricularAdminScore"
-          name="extracurricularAdminScore"
-          type="number"
-          min={0.0}
-          max={10.0}
-          step={0.1}
-          defaultValue={parseFloat(internalReview?.extracurricularAdminScore?.toString() ?? '')}
-        />
-      </LabelText>
-
-      <LabelText label="Exam Comments">
-        <TextField.Root
-          id="examComments"
-          name="examComments"
-          defaultValue={internalReview?.examComments ?? undefined}
-        />
-      </LabelText>
-    </>
+    </Flex>
   )
 }
 

--- a/components/ApplicationTable.tsx
+++ b/components/ApplicationTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import AdminScoringDialog from '@/components/AdminScoringDialog'
+import ReviewerScoringDialog from '@/components/ReviewerScoringDialog'
 import type { Applicant, Application, InternalReview, User } from '@prisma/client'
 import { NextAction } from '@prisma/client'
 import { Card, Flex, Text } from '@radix-ui/themes'
@@ -68,6 +69,10 @@ const columns = [
   columnHelper.display({
     id: 'adminFormButton',
     cell: (info) => <AdminScoringDialog data={info.row.original} />
+  }),
+  columnHelper.display({
+    id: 'reviewerFormButton',
+    cell: (info) => <ReviewerScoringDialog data={info.row.original} />
   })
 ]
 

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import FormWrapper from '@/components/FormWrapper'
+import GenericDialog from '@/components/GenericDialog'
+import LabelText from '@/components/LabelText'
+import { FormPassbackState, upsertReviewerScoring } from '@/lib/forms'
+import { NextActionEnum } from '@/lib/types'
+import { Button, Callout, DataList, Flex, Text, TextField } from '@radix-ui/themes'
+import { format } from 'date-fns'
+import React, { FC, useState } from 'react'
+
+import { ApplicationRow } from './ApplicationTable'
+
+interface ReviewerScoringDialogProps {
+  data: ApplicationRow
+}
+
+interface ReviewerScoringFormProps {
+  data: ApplicationRow
+}
+
+const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
+  const { applicant, internalReview } = data
+
+  return (
+    <Flex direction="column" gap="3">
+      {internalReview?.lastAdminEditOn && internalReview?.lastAdminEditBy && (
+        <Text size="2" className="italic text-gray-500">
+          Last edited by {internalReview?.lastAdminEditBy} on{' '}
+          {format(internalReview?.lastAdminEditOn, "dd/MM/yy 'at' HH:mm")}
+        </Text>
+      )}
+      <Callout.Root>
+        <DataList.Root>
+          <DataList.Item align="center">
+            <DataList.Label>Applicant:</DataList.Label>
+            <DataList.Value className="font-bold">
+              {applicant.firstName} {applicant.surname}
+            </DataList.Value>
+          </DataList.Item>
+          <DataList.Item align="center">
+            <DataList.Label>UCAS number:</DataList.Label>
+            <DataList.Value className="font-bold">{applicant.ucasNumber}</DataList.Value>
+          </DataList.Item>
+
+          <DataList.Item align="center">
+            <DataList.Label color="amber">Admin Motivation Assessment:</DataList.Label>
+            <DataList.Value className="font-bold">
+              {String(internalReview?.motivationAdminScore)}
+            </DataList.Value>
+          </DataList.Item>
+          <DataList.Item align="center">
+            <DataList.Label color="mint">Admin Extracurricular Assessment:</DataList.Label>
+            <DataList.Value className="font-bold">
+              {String(internalReview?.extracurricularAdminScore)}
+            </DataList.Value>
+          </DataList.Item>
+        </DataList.Root>
+      </Callout.Root>
+
+      <Flex direction="column" gap="2">
+        <LabelText label="Motivation Score">
+          <TextField.Root
+            id="motivationReviewerScore"
+            name="motivationReviewerScore"
+            type="number"
+            color="amber"
+            min={0.0}
+            max={10.0}
+            step={0.1}
+            defaultValue={parseFloat(internalReview?.motivationReviewerScore?.toString() ?? '')}
+          />
+        </LabelText>
+
+        <LabelText label="Extracurricular Score">
+          <TextField.Root
+            id="extracurricularReviewerScore"
+            name="extracurricularReviewerScore"
+            type="number"
+            color="mint"
+            min={0.0}
+            max={10.0}
+            step={0.1}
+            defaultValue={parseFloat(
+              internalReview?.extracurricularReviewerScore?.toString() ?? ''
+            )}
+          />
+        </LabelText>
+
+        <LabelText label="Reference Score">
+          <TextField.Root
+            id="referenceReviewerScore"
+            name="referenceReviewerScore"
+            type="number"
+            min={0.0}
+            max={10.0}
+            step={0.1}
+            defaultValue={parseFloat(internalReview?.referenceReviewerScore?.toString() ?? '')}
+          />
+        </LabelText>
+
+        <LabelText label="Academic Comments">
+          <TextField.Root
+            id="academicComments"
+            name="academicComments"
+            defaultValue={internalReview?.academicComments ?? undefined}
+          />
+        </LabelText>
+      </Flex>
+    </Flex>
+  )
+}
+
+const ReviewerScoringDialog: FC<ReviewerScoringDialogProps> = ({ data }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const handleFormSuccess = () => setIsOpen(false)
+
+  const upsertReviewerScoringWithId = (prevState: FormPassbackState, formData: FormData) =>
+    upsertReviewerScoring(NextActionEnum[data.nextAction], data.id, prevState, formData)
+
+  return (
+    <GenericDialog
+      title="Reviewer Scoring Form"
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      trigger={
+        <Button disabled={NextActionEnum[data.nextAction] < NextActionEnum.REVIEWER_SCORING}>
+          Reviewer Scoring Form
+        </Button>
+      }
+    >
+      <FormWrapper action={upsertReviewerScoringWithId} onSuccess={handleFormSuccess}>
+        <ReviewerScoringForm data={data} />
+      </FormWrapper>
+    </GenericDialog>
+  )
+}
+
+export default ReviewerScoringDialog

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -62,6 +62,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
             max={10.0}
             step={0.1}
             defaultValue={parseFloat(internalReview?.motivationReviewerScore?.toString() ?? '')}
+            required
           />
         </LabelText>
 
@@ -77,6 +78,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
             defaultValue={parseFloat(
               internalReview?.extracurricularReviewerScore?.toString() ?? ''
             )}
+            required
           />
         </LabelText>
 
@@ -89,6 +91,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
             max={10.0}
             step={0.1}
             defaultValue={parseFloat(internalReview?.referenceReviewerScore?.toString() ?? '')}
+            required
           />
         </LabelText>
 
@@ -109,7 +112,7 @@ const ReviewerScoringDialog: FC<ReviewerScoringDialogProps> = ({ data }) => {
   const handleFormSuccess = () => setIsOpen(false)
 
   const upsertReviewerScoringWithId = (prevState: FormPassbackState, formData: FormData) =>
-    upsertReviewerScoring(NextActionEnum[data.nextAction], data.id, prevState, formData)
+    upsertReviewerScoring(data.id, prevState, formData)
 
   return (
     <GenericDialog

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -62,6 +62,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
           </DataList.Item>
         </DataList.Root>
       </Callout.Root>
+
       <Flex direction="column" gap="2">
         <LabelText label="Motivation Score">
           <TextField.Root

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -40,13 +40,13 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
           <DataList.Item align="center">
             <DataList.Label color="amber">Admin Motivation Assessment:</DataList.Label>
             <DataList.Value className="font-bold">
-              {String(internalReview?.motivationAdminScore)}
+              {String(internalReview?.motivationAdminScore ?? 'Missing')}
             </DataList.Value>
           </DataList.Item>
           <DataList.Item align="center">
             <DataList.Label color="mint">Admin Extracurricular Assessment:</DataList.Label>
             <DataList.Value className="font-bold">
-              {String(internalReview?.extracurricularAdminScore)}
+              {String(internalReview?.extracurricularAdminScore ?? 'Missing')}
             </DataList.Value>
           </DataList.Item>
         </DataList.Root>

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -5,8 +5,7 @@ import GenericDialog from '@/components/GenericDialog'
 import LabelText from '@/components/LabelText'
 import { FormPassbackState, upsertReviewerScoring } from '@/lib/forms'
 import { NextActionEnum } from '@/lib/types'
-import { Button, Callout, DataList, Flex, Text, TextField } from '@radix-ui/themes'
-import { format } from 'date-fns'
+import { Button, Callout, DataList, Flex, TextField } from '@radix-ui/themes'
 import React, { FC, useState } from 'react'
 
 import { ApplicationRow } from './ApplicationTable'
@@ -24,12 +23,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
 
   return (
     <Flex direction="column" gap="3">
-      {internalReview?.lastAdminEditOn && internalReview?.lastAdminEditBy && (
-        <Text size="2" className="italic text-gray-500">
-          Last edited by {internalReview?.lastAdminEditBy} on{' '}
-          {format(internalReview?.lastAdminEditOn, "dd/MM/yy 'at' HH:mm")}
-        </Text>
-      )}
+      {/*TODO: add last edited for reviewer time*/}
       <Callout.Root>
         <DataList.Root>
           <DataList.Item align="center">
@@ -57,7 +51,6 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
           </DataList.Item>
         </DataList.Root>
       </Callout.Root>
-
       <Flex direction="column" gap="2">
         <LabelText label="Motivation Score">
           <TextField.Root

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -19,6 +19,9 @@ interface ReviewerScoringFormProps {
   data: ApplicationRow
 }
 
+const MOTIVATION_COLOUR = 'amber'
+const EXTRACURRICULAR_COLOUR = 'mint'
+
 const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
   const { applicant, internalReview } = data
 
@@ -44,13 +47,15 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
           </DataList.Item>
 
           <DataList.Item align="center">
-            <DataList.Label color="amber">Admin Motivation Assessment:</DataList.Label>
+            <DataList.Label color={MOTIVATION_COLOUR}>Admin Motivation Assessment:</DataList.Label>
             <DataList.Value className="font-bold">
               {String(internalReview?.motivationAdminScore ?? 'Missing')}
             </DataList.Value>
           </DataList.Item>
           <DataList.Item align="center">
-            <DataList.Label color="mint">Admin Extracurricular Assessment:</DataList.Label>
+            <DataList.Label color={EXTRACURRICULAR_COLOUR}>
+              Admin Extracurricular Assessment:
+            </DataList.Label>
             <DataList.Value className="font-bold">
               {String(internalReview?.extracurricularAdminScore ?? 'Missing')}
             </DataList.Value>
@@ -63,7 +68,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
             id="motivationReviewerScore"
             name="motivationReviewerScore"
             type="number"
-            color="amber"
+            color={MOTIVATION_COLOUR}
             min={0.0}
             max={10.0}
             step={0.1}
@@ -77,7 +82,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
             id="extracurricularReviewerScore"
             name="extracurricularReviewerScore"
             type="number"
-            color="mint"
+            color={EXTRACURRICULAR_COLOUR}
             min={0.0}
             max={10.0}
             step={0.1}
@@ -126,7 +131,10 @@ const ReviewerScoringDialog: FC<ReviewerScoringDialogProps> = ({ data }) => {
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       trigger={
-        <Button disabled={NextActionEnum[data.nextAction] < NextActionEnum.REVIEWER_SCORING}>
+        <Button
+          color="jade"
+          disabled={NextActionEnum[data.nextAction] < NextActionEnum.REVIEWER_SCORING}
+        >
           Reviewer Scoring Form
         </Button>
       }

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -5,7 +5,8 @@ import GenericDialog from '@/components/GenericDialog'
 import LabelText from '@/components/LabelText'
 import { FormPassbackState, upsertReviewerScoring } from '@/lib/forms'
 import { NextActionEnum } from '@/lib/types'
-import { Button, Callout, DataList, Flex, TextField } from '@radix-ui/themes'
+import { Button, Callout, DataList, Flex, Text, TextField } from '@radix-ui/themes'
+import { format } from 'date-fns'
 import React, { FC, useState } from 'react'
 
 import { ApplicationRow } from './ApplicationTable'
@@ -23,7 +24,12 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
 
   return (
     <Flex direction="column" gap="3">
-      {/*TODO: add last edited for reviewer time*/}
+      {internalReview?.lastReviewerEditOn && (
+        <Text size="2" className="italic text-gray-500">
+          Last edited on {format(internalReview.lastReviewerEditOn, "dd/MM/yy 'at' HH:mm")}
+        </Text>
+      )}
+
       <Callout.Root>
         <DataList.Root>
           <DataList.Item align="center">

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -3,8 +3,8 @@
 import FormWrapper from '@/components/FormWrapper'
 import GenericDialog from '@/components/GenericDialog'
 import LabelText from '@/components/LabelText'
-import { FormPassbackState, upsertReviewerScoring } from '@/lib/forms'
-import { NextActionEnum } from '@/lib/types'
+import { upsertReviewerScoring } from '@/lib/forms'
+import { FormPassbackState, NextActionEnum } from '@/lib/types'
 import { Button, Callout, DataList, Flex, Text, TextField } from '@radix-ui/themes'
 import { format } from 'date-fns'
 import React, { FC, useState } from 'react'
@@ -124,7 +124,7 @@ const ReviewerScoringDialog: FC<ReviewerScoringDialogProps> = ({ data }) => {
     <GenericDialog
       title="Reviewer Scoring Form"
       isOpen={isOpen}
-      setIsOpen={setIsOpen}
+      onOpenChange={setIsOpen}
       trigger={
         <Button disabled={NextActionEnum[data.nextAction] < NextActionEnum.REVIEWER_SCORING}>
           Reviewer Scoring Form

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -106,7 +106,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data }) => {
           />
         </LabelText>
 
-        <LabelText label="Academic Comments">
+        <LabelText label="Academic Comments (optional)">
           <TextField.Root
             id="academicComments"
             name="academicComments"

--- a/lib/csv/preprocessing.ts
+++ b/lib/csv/preprocessing.ts
@@ -72,7 +72,9 @@ function processApplicantData(objects: unknown[]): unknown[] {
     ['Entry term', 'admissionsCycle'],
     ['Fee status', 'feeStatus'],
     ['WP flag', 'wideningParticipation'],
-    ['Sent to department', 'applicationDate']
+    ['Sent to department', 'applicationDate'],
+    ['Extenuating circumstances notes', 'extenuatingCircumstances'],
+    ['Academic eligibility notes', 'academicEligibilityNotes']
   ]
   columnsToRename.forEach(([oldName, newName]) => {
     df = df.rename(oldName, newName)
@@ -113,7 +115,9 @@ function processApplicantData(objects: unknown[]): unknown[] {
     'admissionsCycle',
     'feeStatus',
     'wideningParticipation',
-    'applicationDate'
+    'applicationDate',
+    'extenuatingCircumstances',
+    'academicEligibilityNotes'
   ]
   const applicationDf = df.select(...applicationColumns)
   const applicationObjects = applicationDf.toCollection()

--- a/lib/csv/schema.ts
+++ b/lib/csv/schema.ts
@@ -29,7 +29,9 @@ export const schemaApplication = z.object({
     ),
     applicationDate: z
       .string()
-      .transform((value) => formatISO(parseDate(value, 'dd/MM/yyyy HH:mm', new Date())))
+      .transform((value) => formatISO(parseDate(value, 'dd/MM/yyyy HH:mm', new Date()))),
+    extenuatingCircumstances: z.string().nullable(),
+    academicEligibilityNotes: z.string().nullable()
   })
 })
 

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -122,6 +122,7 @@ export const upsertReviewerScoring = async (
     academicComments
   } = result.data
 
+  // move the application to the next stage: UG_TUTOR_REVIEW
   await prisma.application.update({
     where: { id: applicationId },
     data: {

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -10,26 +10,26 @@ import { FormPassbackState, NextActionEnum } from './types'
 const gcseQualificationEnum = z.nativeEnum(GCSEQualification)
 const aLevelQualificationEnum = z.nativeEnum(AlevelQualification)
 
+function numberSchema(from: number, to: number, fieldName: string, isNullable: boolean = false) {
+  let schema = z
+    .number()
+    .gte(from, { message: `${fieldName} must be ≥ ${from}` })
+    .lte(to, { message: `${fieldName} must be ≤ ${to}` })
+
+  return z.preprocess(
+    (val) => (val === '' ? null : Number(val)),
+    isNullable ? schema.nullable() : schema
+  )
+}
+
 const adminFormSchema = z
   .object({
     gcseQualification: gcseQualificationEnum,
-    gcseQualificationScore: z.coerce
-      .number()
-      .gte(0, { message: 'Age 16 exam score must be ≥ 0' })
-      .lte(10, { message: 'Age 16 exam score must be ≤ 10' }),
+    gcseQualificationScore: numberSchema(0, 10, 'Age 16 exam score'),
     aLevelQualification: aLevelQualificationEnum,
-    aLevelQualificationScore: z.coerce
-      .number()
-      .gte(0, { message: 'Age 18 score must be ≥ 0' })
-      .lte(10, { message: 'Age 18 score must be ≤ 10' }),
-    motivationAdminScore: z.coerce
-      .number()
-      .gte(0, { message: 'Motivation assessment score must be ≥ 0' })
-      .lte(10, { message: 'Motivation assessment score must be ≤ 10' }),
-    extracurricularAdminScore: z.coerce
-      .number()
-      .gte(0, { message: 'Extracurricular assessment score must be ≥ 0' })
-      .lte(10, { message: 'Extracurricular assessment score must be ≤ 10' }),
+    aLevelQualificationScore: numberSchema(0, 10, 'Age 18 exam score'),
+    motivationAdminScore: numberSchema(0, 10, 'Motivation Assessments', true),
+    extracurricularAdminScore: numberSchema(0, 10, 'Extracurricular Assessments', true),
     examComments: z.string()
   })
   .partial()

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -93,18 +93,9 @@ export const upsertAdminScoring = async (
 }
 
 const reviewerFormSchema = z.object({
-  motivationReviewerScore: z.coerce
-    .number()
-    .gte(0, { message: 'Motivation score must be ≥ 0' })
-    .lte(10, { message: 'Motivation score must be ≤ 10' }),
-  extracurricularReviewerScore: z.coerce
-    .number()
-    .gte(0, { message: 'Extracurricular score must be ≥ 0' })
-    .lte(10, { message: 'Extracurricular score must be ≤ 10' }),
-  referenceReviewerScore: z.coerce
-    .number()
-    .gte(0, { message: 'Reference score must be ≥ 0' })
-    .lte(10, { message: 'Reference score must be ≤ 10' }),
+  motivationReviewerScore: numberSchema(0, 10, 'Motivation Score'),
+  extracurricularReviewerScore: numberSchema(0, 10, 'Extracurricular Score'),
+  referenceReviewerScore: numberSchema(0, 10, 'Reference Score'),
   academicComments: z.string()
 })
 

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -88,12 +88,53 @@ export const upsertAdminScoring = async (
   return { status: 'success', message: 'Admin scoring form updated successfully.' }
 }
 
+const reviewerFormSchema = z.object({
+  motivationReviewerScore: z.coerce
+    .number()
+    .gte(0, { message: 'Motivation score must be ≥ 0' })
+    .lte(10, { message: 'Motivation score must be ≤ 10' }),
+  extracurricularReviewerScore: z.coerce
+    .number()
+    .gte(0, { message: 'Extracurricular score must be ≥ 0' })
+    .lte(10, { message: 'Extracurricular score must be ≤ 10' }),
+  referenceReviewerScore: z.coerce
+    .number()
+    .gte(0, { message: 'Reference score must be ≥ 0' })
+    .lte(10, { message: 'Reference score must be ≤ 10' }),
+  academicComments: z.string()
+})
+
 export const upsertReviewerScoring = async (
-  currentAction: NextActionEnum,
   applicationId: number,
   _: FormPassbackState,
   formData: FormData
 ): Promise<FormPassbackState> => {
+  const result = reviewerFormSchema.safeParse(Object.fromEntries(formData))
+  if (!result.success) return { status: 'error', message: result.error.issues[0].message }
+  const {
+    motivationReviewerScore,
+    extracurricularReviewerScore,
+    referenceReviewerScore,
+    academicComments
+  } = result.data
+
+  await prisma.application.update({
+    where: { id: applicationId },
+    data: {
+      nextAction: NextAction.UG_TUTOR_REVIEW
+    }
+  })
+
+  await prisma.internalReview.update({
+    where: { applicationId },
+    data: {
+      motivationReviewerScore,
+      extracurricularReviewerScore,
+      referenceReviewerScore,
+      academicComments
+    }
+  })
+
   revalidatePath('/')
   return { status: 'success', message: 'Reviewer scoring form updated successfully.' }
 }

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -87,3 +87,13 @@ export const upsertAdminScoring = async (
   revalidatePath('/')
   return { status: 'success', message: 'Admin scoring form updated successfully.' }
 }
+
+export const upsertReviewerScoring = async (
+  currentAction: NextActionEnum,
+  applicationId: number,
+  _: FormPassbackState,
+  formData: FormData
+): Promise<FormPassbackState> => {
+  revalidatePath('/')
+  return { status: 'success', message: 'Reviewer scoring form updated successfully.' }
+}

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -75,12 +75,16 @@ export const upsertAdminScoring = async (
       applicationId,
       motivationAdminScore,
       extracurricularAdminScore,
-      examComments
+      examComments,
+      lastAdminEditBy: 'admin', // TODO: get the actual admin user
+      lastAdminEditOn: new Date()
     },
     update: {
       motivationAdminScore,
       extracurricularAdminScore,
-      examComments
+      examComments,
+      lastAdminEditBy: 'admin', // TODO: get the actual admin user
+      lastAdminEditOn: new Date()
     }
   })
 
@@ -131,7 +135,8 @@ export const upsertReviewerScoring = async (
       motivationReviewerScore,
       extracurricularReviewerScore,
       referenceReviewerScore,
-      academicComments
+      academicComments,
+      lastReviewerEditOn: new Date()
     }
   })
 

--- a/prisma/migrations/20240913151549_add_extenuating_circumstances_to_application/migration.sql
+++ b/prisma/migrations/20240913151549_add_extenuating_circumstances_to_application/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Application" ADD COLUMN     "extenuatingCircumstances" TEXT;

--- a/prisma/migrations/20240916103106_add_reviewer_scores_to_internal_review/migration.sql
+++ b/prisma/migrations/20240916103106_add_reviewer_scores_to_internal_review/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "InternalReview" ADD COLUMN     "academicComments" TEXT,
+ADD COLUMN     "extracurricularReviewerScore" DECIMAL(3,1),
+ADD COLUMN     "motivationReviewerScore" DECIMAL(3,1),
+ADD COLUMN     "referenceReviewerScore" DECIMAL(3,1);

--- a/prisma/migrations/20240916113731_set_timestamps_for_admin_and_reviewer_edits_manually/migration.sql
+++ b/prisma/migrations/20240916113731_set_timestamps_for_admin_and_reviewer_edits_manually/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "InternalReview" ADD COLUMN     "lastReviewerEditOn" TIMESTAMP(3),
+ALTER COLUMN "lastAdminEditOn" DROP NOT NULL;

--- a/prisma/migrations/20240916131437_add_academic_eligibility_to_application/migration.sql
+++ b/prisma/migrations/20240916131437_add_academic_eligibility_to_application/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Application" ADD COLUMN     "academicEligibilityNotes" TEXT;

--- a/prisma/schema/application.prisma
+++ b/prisma/schema/application.prisma
@@ -49,6 +49,8 @@ model Application {
   /// aLevelQualification is an enum that corresponds to age 18, A-Level-equivalent qualification type
   aLevelQualification      AlevelQualification?
   aLevelQualificationScore Decimal?             @db.Decimal(3, 1)
+  extenuatingCircumstances String?
+  academicEligibilityNotes String?
   /// internalReview contains all scores and comments from admins, reviewers and UG tutors
   internalReview           InternalReview?
   /// nextAction is an enum referring to the action pending completion for the application to progress

--- a/prisma/schema/application.prisma
+++ b/prisma/schema/application.prisma
@@ -62,12 +62,16 @@ model Application {
 }
 
 model InternalReview {
-  id                        Int         @id @default(autoincrement())
-  application               Application @relation(fields: [applicationId], references: [id])
-  applicationId             Int         @unique
-  motivationAdminScore      Decimal?    @db.Decimal(3, 1)
-  extracurricularAdminScore Decimal?    @db.Decimal(3, 1)
-  examComments              String?
-  lastAdminEditBy           String?
-  lastAdminEditOn           DateTime    @updatedAt
+  id                           Int         @id @default(autoincrement())
+  application                  Application @relation(fields: [applicationId], references: [id])
+  applicationId                Int         @unique
+  motivationAdminScore         Decimal?    @db.Decimal(3, 1)
+  extracurricularAdminScore    Decimal?    @db.Decimal(3, 1)
+  examComments                 String?
+  lastAdminEditBy              String?
+  lastAdminEditOn              DateTime    @updatedAt
+  motivationReviewerScore      Decimal?    @db.Decimal(3, 1)
+  extracurricularReviewerScore Decimal?    @db.Decimal(3, 1)
+  referenceReviewerScore       Decimal?    @db.Decimal(3, 1)
+  academicComments             String?
 }

--- a/prisma/schema/application.prisma
+++ b/prisma/schema/application.prisma
@@ -69,9 +69,10 @@ model InternalReview {
   extracurricularAdminScore    Decimal?    @db.Decimal(3, 1)
   examComments                 String?
   lastAdminEditBy              String?
-  lastAdminEditOn              DateTime    @updatedAt
+  lastAdminEditOn              DateTime?
   motivationReviewerScore      Decimal?    @db.Decimal(3, 1)
   extracurricularReviewerScore Decimal?    @db.Decimal(3, 1)
   referenceReviewerScore       Decimal?    @db.Decimal(3, 1)
   academicComments             String?
+  lastReviewerEditOn           DateTime?
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -67,8 +67,6 @@ const createReview = (application: Application) => {
     motivationAdminScore: faker.number.float({ multipleOf: 0.1, min: 0.0, max: 10.0 }),
     extracurricularAdminScore: faker.number.float({ multipleOf: 0.1, min: 0.0, max: 10.0 }),
     examComments: faker.person.bio(),
-    lastAdminEditBy:
-      faker.string.alpha({ length: 2 }).toLowerCase() + faker.string.numeric({ length: 3 }),
     application: {
       connect: {
         id: application.id
@@ -83,9 +81,7 @@ async function main() {
 
     for (let j = 0; j < 10; j++) {
       const application = await prisma.application.create({ data: createApplication(user) })
-      if (j % 2 == 0) {
-        await prisma.internalReview.create({ data: createReview(application) })
-      }
+      await prisma.internalReview.create({ data: createReview(application) })
     }
   }
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -52,6 +52,8 @@ const createApplication = (reviewer: User) => {
       Object.keys(AlevelQualification)
     ) as AlevelQualification,
     aLevelQualificationScore: faker.number.float({ multipleOf: 0.1, min: 0.0, max: 10.0 }),
+    extenuatingCircumstances: faker.lorem.text(),
+    academicEligibilityNotes: faker.lorem.text(),
     reviewer: {
       connect: {
         id: reviewer.id


### PR DESCRIPTION
**UI**
- Add column with reviewer scoring form button (greyed out if nextAction <= admin scoring)
  - ![Screenshot 2024-09-16 at 16 13 04](https://github.com/user-attachments/assets/af0215e2-c509-4757-aafb-affdbf08bfbc)
- Reviewer scoring form displays admin scores for motivation and extracurricular assessments in a callout
  - ![Screenshot 2024-09-16 at 16 13 50](https://github.com/user-attachments/assets/394607ee-754c-4f97-a5a4-220b1fb7a5b8)
- Reviewer form mandates all 3 scores be entered but academic comments are optional
- Make admin scoring form consistent by also using a DataList in its callout
  - ![Screenshot 2024-09-16 at 16 17 53](https://github.com/user-attachments/assets/d9871347-54fe-4cef-b422-62c5be5a8f9b)


**Server**
- Expand schema to accommodate reviewer-specific data (motivationReviewerScore, extracurricularReviewerScore , referenceReviewerScore, academicComments, lastReviewerEditOn)
- Server action for updating the internal review with data from the reviewer scoring form
- Set timestamps manually for lastAdminEditOn and lastReviewerEditOn (rather than @updatedAt) so they change only on the correct form