### PR TITLE
feat: reviewer allocation

### DIFF
--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -205,7 +205,8 @@ const AdminScoringDialog: FC<AdminScoringDialogProps> = ({ data }) => {
       onOpenChange={setIsOpen}
       trigger={
         <Button
-          className="min-h-12"
+          className="min-h-10"
+          color={'cyan'}
           disabled={NextActionEnum[data.nextAction] < NextActionEnum.ADMIN_SCORING}
         >
           Admin Scoring Form

--- a/components/DataUploadDialog.tsx
+++ b/components/DataUploadDialog.tsx
@@ -73,7 +73,7 @@ const DataUploadDialog: FC = () => {
   return (
     <GenericDialog
       title={'Data Upload'}
-      trigger={<Button>Data Upload</Button>}
+      trigger={<Button className="min-h-10">Data Upload</Button>}
       isOpen={isDialogOpen}
       onOpenChange={(isOpen) => {
         if (!isOpen) setFile(null)

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -134,7 +134,7 @@ const ReviewerScoringDialog: FC<ReviewerScoringDialogProps> = ({ data }) => {
       trigger={
         <Button
           color="jade"
-          className="min-h-12"
+          className="min-h-10"
           disabled={NextActionEnum[data.nextAction] < NextActionEnum.REVIEWER_SCORING}
         >
           Reviewer Scoring Form

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -49,7 +49,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, setCurrentTab }) => {
   const sortedComments = useMemo(
     () =>
       internalReview?.generalComments.toSorted(
-        (a: Comment, b: Comment) => new Date(b.madeOn) - new Date(a.madeOn)
+        (a: Comment, b: Comment) => new Date(b.madeOn).getTime() - new Date(a.madeOn).getTime()
       ) ?? [],
     [internalReview?.generalComments]
   )

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -200,7 +200,11 @@ const UgTutorDialog: FC<UgTutorDialogProps> = ({ data }) => {
       title="UG Tutor Form"
       isOpen={isOpen}
       onOpenChange={setIsOpen}
-      trigger={<Button className="min-h-12">UG Tutor Form</Button>}
+      trigger={
+        <Button className="min-h-10" color="ruby">
+          UG Tutor Form
+        </Button>
+      }
     >
       <FormWrapper
         action={currentTab === 'outcomes' ? upsertOutcomeWithId : addCommentWithId}

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -23,13 +23,14 @@ import {
 import React, { FC, useMemo, useState } from 'react'
 
 interface UgTutorDialogProps {
-  data: ApplicationRow
+  // generalComments relation does not type check otherwise
+  data: ApplicationRow & { internalReview: { generalComments: Comment[] } }
 }
 
 type Tab = 'outcomes' | 'comments'
 
 interface UgTutorFormProps {
-  data: ApplicationRow
+  data: ApplicationRow & { internalReview: { generalComments: Comment[] } }
   setCurrentTab: (tab: Tab) => void
 }
 

--- a/lib/csv/upload.ts
+++ b/lib/csv/upload.ts
@@ -147,16 +147,16 @@ export const processCsvUpload = async (
 
   const noPrismaErrors = upsertPromises.length - successfulUpserts.length
   const totalErrors = noParsingErrors + noPrismaErrors
-  const noSuccesses = successfulUpserts.length - totalErrors
+  const noSuccesses = objects.length - totalErrors
 
   if (totalErrors === 0) {
     return {
-      message: `${noSuccesses}/${successfulUpserts.length} updates or inserts succeeded`,
+      message: `${noSuccesses}/${objects.length} updates or inserts succeeded`,
       status: 'success'
     }
   }
   return {
-    message: `${totalErrors}/${successfulUpserts.length} updates or inserts failed`,
+    message: `${totalErrors}/${objects.length} updates or inserts failed`,
     status: 'error'
   }
 }

--- a/lib/reviewerAllocation.ts
+++ b/lib/reviewerAllocation.ts
@@ -4,7 +4,7 @@ import { Application, Role } from '@prisma/client'
 /**
  * Retrieves reviewers with application count from the database
  */
-const getReviewersWithApplicationCount = async () =>
+const getReviewersWithAscApplicationCount = async () =>
   await prisma.user.findMany({
     where: {
       role: Role.REVIEWER
@@ -15,16 +15,22 @@ const getReviewersWithApplicationCount = async () =>
           applications: true
         }
       }
+    },
+    orderBy: {
+      applications: {
+        _count: 'asc'
+      }
     }
   })
 
 /**
- * Accepts a list of applications to a specific reviewer
+ * Accepts a list of applications and assigns to a specific reviewer
  * @param applications - a list of applications that will be assigned a reviewer
  * @param reviewerId - a reviewer id to be assigned to the applications
+ * @returns - a Promise that resolves to the updated user object
  */
-const allocateApplicationsToReviewer = async (applications: Application[], reviewerId: number) => {
-  await prisma.user.update({
+const allocateApplicationsToReviewer = (applications: Application[], reviewerId: number) =>
+  prisma.user.update({
     where: {
       id: reviewerId
     },
@@ -34,6 +40,30 @@ const allocateApplicationsToReviewer = async (applications: Application[], revie
       }
     }
   })
+
+/**
+ * Divides a total number into equal partitions and distributes the remainder evenly from the beginning.
+ * @param total - The total number of items to be divided into partitions.
+ * @param parts - The number of partitions to create.
+ * @returns An array of tuples, where each tuple contains the start and end
+ *          indices of each partition, represented as [startIndex, endIndex].
+ *          The indices can be used to slice an array into the desired partitions.
+ * @example
+ * // Example: Dividing 10 items into 3 partitions
+ * const partitions = getEqualPartition(10, 3);
+ * // partitions will be: [[0, 4], [4, 7], [7, 10]]
+ */
+const getEqualPartition = (total: number, parts: number): [number, number][] => {
+  const quotient = Math.floor(total / parts)
+  const remainder = total % parts
+  const result: [number, number][] = []
+  let added = 0
+  for (let i = 0; i < parts; i++) {
+    const intervalLen = quotient + (i < remainder ? 1 : 0)
+    result.push([added, added + intervalLen])
+    added += intervalLen
+  }
+  return result
 }
 
 /**
@@ -43,35 +73,23 @@ const allocateApplicationsToReviewer = async (applications: Application[], revie
  *
  *  The function:
  *  - Retrieves the current application count per reviewer.
- *  - Computes the fair share of applications for each reviewer based on the total applications (new and already assigned).
- *  - Assigns applications accordingly, taking into account any remainder to ensure all applications are allocated.
+ *  - Gets a partition to split the total applications evenly across the reviewers (including the remainder).
+ *  - Assigns applications accordingly in an asynchronous manner.
  * @param applications
  */
 export const allocateApplications = async (applications: Application[]) => {
   // assign reviewers only to applications that don't have one
   applications = applications.filter((application) => application.reviewerId === null)
-  const applicationsCount = applications.length
-  const reviewersWithCount = await getReviewersWithApplicationCount()
+  const reviewersWithCount = await getReviewersWithAscApplicationCount()
   const reviewersCount = reviewersWithCount.length
   if (reviewersCount === 0)
     throw new Error(
       'Reviewer allocation failed because no reviewers were found. Please upload reviewers and try again.'
     )
-  const assignedApplicationsCount = reviewersWithCount.reduce(
-    (acc, reviewer) => acc + reviewer._count.applications,
-    0
+
+  const slices = getEqualPartition(applications.length, reviewersCount)
+  const allocations = reviewersWithCount.map((reviewer, i) =>
+    allocateApplicationsToReviewer(applications.slice(...slices[i]), reviewer.id)
   )
-  const totalApplicationsCount = applicationsCount + assignedApplicationsCount
-  const quotient = Math.floor(totalApplicationsCount / reviewersCount)
-  const remainder = totalApplicationsCount % reviewersCount
-  let assignedCount = 0
-  for (const reviewer of reviewersWithCount) {
-    const i = reviewersWithCount.indexOf(reviewer)
-    const newApplicationsCount = quotient - reviewer._count.applications + Number(i < remainder)
-    await allocateApplicationsToReviewer(
-      applications.slice(assignedCount, assignedCount + newApplicationsCount),
-      reviewer.id
-    )
-    assignedCount += newApplicationsCount
-  }
+  await Promise.all(allocations)
 }

--- a/lib/reviewerAllocation.ts
+++ b/lib/reviewerAllocation.ts
@@ -1,0 +1,71 @@
+import prisma from '@/db'
+import { Application, Role } from '@prisma/client'
+
+/**
+ * Retrieves reviewers with application count from the database
+ */
+const getReviewersWithApplicationCount = async () =>
+  await prisma.user.findMany({
+    where: {
+      role: Role.REVIEWER
+    },
+    include: {
+      _count: {
+        select: {
+          applications: true
+        }
+      }
+    }
+  })
+
+/**
+ * Accepts a list of applications to a specific reviewer
+ * @param applications - a list of applications that will be assigned a reviewer
+ * @param reviewerId - a reviewer id to be assigned to the applications
+ */
+const allocateApplicationsToReviewer = async (applications: Application[], reviewerId: number) => {
+  await prisma.user.update({
+    where: {
+      id: reviewerId
+    },
+    data: {
+      applications: {
+        connect: applications.map((application) => ({ id: application.id }))
+      }
+    }
+  })
+}
+
+/**
+ *  Distributes a list of applications evenly among a set of reviewers. Each reviewer will be assigned
+ *  a number of applications based on the total number of applications and the number of reviewers,
+ *  attempting to balance the load across reviewers.
+ *
+ *  The function:
+ *  - Retrieves the current application count per reviewer.
+ *  - Computes the fair share of applications for each reviewer based on the total applications (new and already assigned).
+ *  - Assigns applications accordingly, taking into account any remainder to ensure all applications are allocated.
+ * @param applications
+ */
+export const allocateApplications = async (applications: Application[]) => {
+  const applicationsCount = applications.length
+  const reviewersWithCount = await getReviewersWithApplicationCount()
+  const reviewersCount = reviewersWithCount.length
+  const assignedApplicationsCount = reviewersWithCount.reduce(
+    (acc, reviewer) => acc + reviewer._count.applications,
+    0
+  )
+  const totalApplicationsCount = applicationsCount + assignedApplicationsCount
+  const quotient = totalApplicationsCount / reviewersCount
+  const remainder = totalApplicationsCount % reviewersCount
+  let assignedCount = 0
+  for (const reviewer of reviewersWithCount) {
+    const i = reviewersWithCount.indexOf(reviewer)
+    const newApplicationsCount = quotient - reviewer._count.applications + Number(i < remainder)
+    await allocateApplicationsToReviewer(
+      applications.slice(assignedCount, newApplicationsCount),
+      reviewer.id
+    )
+    assignedCount += newApplicationsCount
+  }
+}


### PR DESCRIPTION
Implement a possible reviewer allocation algorithm.

The algorithm relies on the following invariant: the difference in the number of applications between the reviewer with the most applications and the reviewer with the fewest applications is **at most 1**.

Here's a diagram that illustrates how the algorithm works:
![photo_2024-09-19 16 41 47](https://github.com/user-attachments/assets/b0dcb567-e2f9-4cc4-be03-14003d379638)

Potential improvements: allocation will not work if the invariant is not preserved - in cases where there's a gap bigger than 1 between the number of assigned applications. Therefore, it is possible to make the algorithm more robust to account for that.