### PR TITLE
feat: upload and view TMUA grades

### DIFF
--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import CandidateCallout from '@/components/CandidateCallout'
 import Dropdown from '@/components/Dropdown'
 import FormWrapper from '@/components/FormWrapper'
 import GenericDialog from '@/components/GenericDialog'
@@ -10,16 +11,7 @@ import { FormPassbackState, NextActionEnum } from '@/lib/types'
 import { decimalToNumber } from '@/lib/utils'
 import { AlevelQualification, GCSEQualification, Role } from '@prisma/client'
 import { FileTextIcon, IdCardIcon } from '@radix-ui/react-icons'
-import {
-  Button,
-  Callout,
-  DataList,
-  Flex,
-  Heading,
-  Popover,
-  Text,
-  TextField
-} from '@radix-ui/themes'
+import { Button, Flex, Heading, Popover, Text, TextField } from '@radix-ui/themes'
 import { format } from 'date-fns'
 import React, { FC, useState } from 'react'
 
@@ -52,20 +44,12 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
           {format(internalReview.lastAdminEditOn, "dd/MM/yy 'at' HH:mm")}
         </Text>
       )}
-      <Callout.Root>
-        <DataList.Root>
-          <DataList.Item align="center">
-            <DataList.Label>Applicant:</DataList.Label>
-            <DataList.Value className="font-bold">
-              {applicant.firstName} {applicant.surname}
-            </DataList.Value>
-          </DataList.Item>
-          <DataList.Item align="center">
-            <DataList.Label>UCAS number:</DataList.Label>
-            <DataList.Value className="font-bold">{applicant.ucasNumber}</DataList.Value>
-          </DataList.Item>
-        </DataList.Root>
-      </Callout.Root>
+
+      <CandidateCallout
+        firstName={applicant.firstName}
+        surname={applicant.surname}
+        ucasNumber={applicant.ucasNumber}
+      />
 
       <TmuaGradeBox
         paper1Score={data.tmuaPaper1Score}

--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -51,11 +51,14 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
         ucasNumber={applicant.ucasNumber}
       />
 
-      <TmuaGradeBox
-        paper1Score={data.tmuaPaper1Score}
-        paper2Score={data.tmuaPaper2Score}
-        overallScore={data.tmuaOverallScore}
-      />
+      {/* Reviewers should not be able to see TMUA grades */}
+      {!readOnly && (
+        <TmuaGradeBox
+          paper1Score={data.tmuaPaper1Score}
+          paper2Score={data.tmuaPaper2Score}
+          overallScore={data.tmuaOverallScore}
+        />
+      )}
 
       <Flex direction="column" gap="2">
         <Flex direction="column" gap="2">

--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -4,8 +4,10 @@ import Dropdown from '@/components/Dropdown'
 import FormWrapper from '@/components/FormWrapper'
 import GenericDialog from '@/components/GenericDialog'
 import LabelText from '@/components/LabelText'
+import TmuaGradeBox from '@/components/TmuaGradeBox'
 import { upsertAdminScoring } from '@/lib/forms'
 import { FormPassbackState, NextActionEnum } from '@/lib/types'
+import { decimalToNumber } from '@/lib/utils'
 import { AlevelQualification, GCSEQualification, Role } from '@prisma/client'
 import { FileTextIcon, IdCardIcon } from '@radix-ui/react-icons'
 import {
@@ -64,6 +66,12 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
           </DataList.Item>
         </DataList.Root>
       </Callout.Root>
+
+      <TmuaGradeBox
+        paper1Score={data.tmuaPaper1Score}
+        paper2Score={data.tmuaPaper2Score}
+        overallScore={data.tmuaOverallScore}
+      />
 
       <Flex direction="column" gap="2">
         <Flex direction="column" gap="2">
@@ -124,7 +132,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
               className="flex-grow"
               disabled={!gcseQualification || readOnly}
               required={!!gcseQualification}
-              defaultValue={parseFloat(data?.gcseQualificationScore?.toString() ?? '')}
+              defaultValue={decimalToNumber(data?.gcseQualificationScore)}
             />
           </LabelText>
         </Flex>
@@ -155,7 +163,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
               className="flex-grow"
               disabled={!aLevelQualification || readOnly}
               required={!!aLevelQualification}
-              defaultValue={parseFloat(data?.aLevelQualificationScore?.toString() ?? '')}
+              defaultValue={decimalToNumber(data?.aLevelQualificationScore)}
             />
           </LabelText>
         </Flex>
@@ -168,7 +176,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
             min={0.0}
             max={10.0}
             step={0.1}
-            defaultValue={parseFloat(internalReview?.motivationAdminScore?.toString() ?? '')}
+            defaultValue={decimalToNumber(internalReview?.motivationAdminScore)}
             disabled={readOnly}
           />
         </LabelText>
@@ -181,7 +189,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
             min={0.0}
             max={10.0}
             step={0.1}
-            defaultValue={parseFloat(internalReview?.extracurricularAdminScore?.toString() ?? '')}
+            defaultValue={decimalToNumber(internalReview?.extracurricularAdminScore)}
             disabled={readOnly}
           />
         </LabelText>

--- a/components/CandidateCallout.tsx
+++ b/components/CandidateCallout.tsx
@@ -1,0 +1,29 @@
+import { Callout, DataList } from '@radix-ui/themes'
+import React, { FC } from 'react'
+
+interface CandidateCalloutProps {
+  firstName: string
+  surname: string
+  ucasNumber: string
+}
+
+const CandidateCallout: FC<CandidateCalloutProps> = ({ firstName, surname, ucasNumber }) => {
+  return (
+    <Callout.Root>
+      <DataList.Root>
+        <DataList.Item align="center">
+          <DataList.Label>Applicant:</DataList.Label>
+          <DataList.Value className="font-bold">
+            {firstName} {surname}
+          </DataList.Value>
+        </DataList.Item>
+        <DataList.Item align="center">
+          <DataList.Label>UCAS number:</DataList.Label>
+          <DataList.Value className="font-bold">{ucasNumber}</DataList.Value>
+        </DataList.Item>
+      </DataList.Root>
+    </Callout.Root>
+  )
+}
+
+export default CandidateCallout

--- a/components/DataUploadDialog.tsx
+++ b/components/DataUploadDialog.tsx
@@ -91,6 +91,9 @@ const DataUploadDialog: FC<DataUploadDialogProps> = ({ disabled }) => {
       <FormWrapper action={processCsvUploadWrapped} submitButtonText="Upload">
         <DataUploadForm file={file} setFile={setFile} />
       </FormWrapper>
+      <Button color="teal" onClick={() => window.location.reload()}>
+        <em>After uploading, refresh to see changes</em>
+      </Button>
     </GenericDialog>
   )
 }

--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import CandidateCallout from '@/components/CandidateCallout'
 import FormWrapper from '@/components/FormWrapper'
 import GenericDialog from '@/components/GenericDialog'
 import LabelText from '@/components/LabelText'
@@ -35,19 +36,14 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data, readOnly }) =
         </Text>
       )}
 
+      <CandidateCallout
+        firstName={applicant.firstName}
+        surname={applicant.surname}
+        ucasNumber={applicant.ucasNumber}
+      />
+
       <Callout.Root>
         <DataList.Root>
-          <DataList.Item align="center">
-            <DataList.Label>Applicant:</DataList.Label>
-            <DataList.Value className="font-bold">
-              {applicant.firstName} {applicant.surname}
-            </DataList.Value>
-          </DataList.Item>
-          <DataList.Item align="center">
-            <DataList.Label>UCAS number:</DataList.Label>
-            <DataList.Value className="font-bold">{applicant.ucasNumber}</DataList.Value>
-          </DataList.Item>
-
           <DataList.Item align="center">
             <DataList.Label color={MOTIVATION_COLOUR}>Admin Motivation Assessment:</DataList.Label>
             <DataList.Value className="font-bold">

--- a/components/TmuaGradeBox.tsx
+++ b/components/TmuaGradeBox.tsx
@@ -1,0 +1,39 @@
+import { decimalToString } from '@/lib/utils'
+import { Decimal } from '@prisma/client/runtime/binary'
+import { Card, Flex, Heading, Table } from '@radix-ui/themes'
+import React, { FC } from 'react'
+
+interface TmuaGradeBoxProps {
+  paper1Score: Decimal | null
+  paper2Score: Decimal | null
+  overallScore: Decimal | null
+}
+
+const TmuaGradeBox: FC<TmuaGradeBoxProps> = ({ paper1Score, paper2Score, overallScore }) => {
+  return (
+    <Card className="bg-gray-300">
+      <Flex direction="column" gap="2">
+        <Heading size={'2'}>TMUA Grades (scored from 1 to 9)</Heading>
+        <Table.Root variant="surface">
+          <Table.Header>
+            <Table.Row>
+              <Table.ColumnHeaderCell>Paper 1</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Paper 2</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell>Overall</Table.ColumnHeaderCell>
+            </Table.Row>
+          </Table.Header>
+
+          <Table.Body>
+            <Table.Row>
+              <Table.RowHeaderCell>{decimalToString(paper1Score)}</Table.RowHeaderCell>
+              <Table.Cell>{decimalToString(paper2Score)}</Table.Cell>
+              <Table.Cell>{decimalToString(overallScore)}</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Root>
+      </Flex>
+    </Card>
+  )
+}
+
+export default TmuaGradeBox

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -4,6 +4,7 @@ import Dropdown from '@/components/Dropdown'
 import FormWrapper from '@/components/FormWrapper'
 import GenericDialog from '@/components/GenericDialog'
 import LabelText from '@/components/LabelText'
+import TmuaGradeBox from '@/components/TmuaGradeBox'
 import { insertComment, upsertOutcome } from '@/lib/forms'
 import { FormPassbackState } from '@/lib/types'
 import {
@@ -80,6 +81,12 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
           </DataList.Item>
         </DataList.Root>
       </Callout.Root>
+
+      <TmuaGradeBox
+        paper1Score={data.tmuaPaper1Score}
+        paper2Score={data.tmuaPaper2Score}
+        overallScore={data.tmuaOverallScore}
+      />
 
       <Tabs.Root defaultValue="outcomes" onValueChange={(tabName) => setCurrentTab(tabName as Tab)}>
         <Tabs.List>

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -1,4 +1,5 @@
 import { ApplicationRow } from '@/components/ApplicationTable'
+import CandidateCallout from '@/components/CandidateCallout'
 import CommentItem from '@/components/CommentItem'
 import Dropdown from '@/components/Dropdown'
 import FormWrapper from '@/components/FormWrapper'
@@ -17,9 +18,7 @@ import {
 import {
   Box,
   Button,
-  Callout,
   Card,
-  DataList,
   Flex,
   Heading,
   Separator,
@@ -67,20 +66,11 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
 
   return (
     <Flex direction="column" gap="3">
-      <Callout.Root>
-        <DataList.Root>
-          <DataList.Item align="center">
-            <DataList.Label>Applicant:</DataList.Label>
-            <DataList.Value className="font-bold">
-              {applicant.firstName} {applicant.surname}
-            </DataList.Value>
-          </DataList.Item>
-          <DataList.Item align="center">
-            <DataList.Label>UCAS number:</DataList.Label>
-            <DataList.Value className="font-bold">{applicant.ucasNumber}</DataList.Value>
-          </DataList.Item>
-        </DataList.Root>
-      </Callout.Root>
+      <CandidateCallout
+        firstName={applicant.firstName}
+        surname={applicant.surname}
+        ucasNumber={applicant.ucasNumber}
+      />
 
       <TmuaGradeBox
         paper1Score={data.tmuaPaper1Score}

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -72,11 +72,14 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
         ucasNumber={applicant.ucasNumber}
       />
 
-      <TmuaGradeBox
-        paper1Score={data.tmuaPaper1Score}
-        paper2Score={data.tmuaPaper2Score}
-        overallScore={data.tmuaOverallScore}
-      />
+      {/* Reviewers should not be able to see TMUA grades */}
+      {!readOnly && (
+        <TmuaGradeBox
+          paper1Score={data.tmuaPaper1Score}
+          paper2Score={data.tmuaPaper2Score}
+          overallScore={data.tmuaOverallScore}
+        />
+      )}
 
       <Tabs.Root defaultValue="outcomes" onValueChange={(tabName) => setCurrentTab(tabName as Tab)}>
         <Tabs.List>

--- a/lib/csv/schema.ts
+++ b/lib/csv/schema.ts
@@ -41,6 +41,7 @@ export const schemaApplication = z.object({
 // used to insert TMUA grades
 export const schemaTMUAScores = z.object({
   cid: z.string().length(8, { message: 'CID must be exactly 8 characters' }),
+  admissionsCycle: z.coerce.number().int().positive(),
   tmuaPaper1Score: z.coerce.number().min(1).max(9).optional(),
   tmuaPaper2Score: z.coerce.number().min(1).max(9).optional(),
   tmuaOverallScore: z.coerce.number().min(1).max(9).optional()

--- a/lib/csv/upload.ts
+++ b/lib/csv/upload.ts
@@ -101,7 +101,8 @@ function updateTmuaScores(scores: z.infer<typeof schemaTMUAScores>[]) {
       data: {
         tmuaPaper1Score: s.tmuaPaper1Score,
         tmuaPaper2Score: s.tmuaPaper2Score,
-        tmuaOverallScore: s.tmuaOverallScore
+        tmuaOverallScore: s.tmuaOverallScore,
+        nextAction: 'ADMIN_SCORING'
       }
     })
   })

--- a/lib/csv/upload.ts
+++ b/lib/csv/upload.ts
@@ -88,8 +88,23 @@ function upsertApplication(applications: z.infer<typeof schemaApplication>[]) {
   })
 }
 
-function upsertTMUAScores(scores: any[]) {
-  return [new Promise((resolve, reject) => {})]
+// application must already exist
+function updateTmuaScores(scores: z.infer<typeof schemaTMUAScores>[]) {
+  return scores.map((s) => {
+    return prisma.application.update({
+      where: {
+        admissionsCycle_applicantCid: {
+          admissionsCycle: s.admissionsCycle,
+          applicantCid: s.cid
+        }
+      },
+      data: {
+        tmuaPaper1Score: s.tmuaPaper1Score,
+        tmuaPaper2Score: s.tmuaPaper2Score,
+        tmuaOverallScore: s.tmuaOverallScore
+      }
+    })
+  })
 }
 
 /**
@@ -147,7 +162,7 @@ export const processCsvUpload = async (
     case DataUploadEnum.TMUA_SCORES: {
       const { data: parsedTMUAData, noErrors } = parseWithSchema(objects, schemaTMUAScores)
       noParsingErrors = noErrors
-      upsertPromises = upsertTMUAScores(parsedTMUAData)
+      upsertPromises = updateTmuaScores(parsedTMUAData)
       break
     }
     case DataUploadEnum.USER_ROLES: {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,14 @@
+import { Decimal } from '@prisma/client/runtime/binary'
+
+// null and undefined are converted to NaN
+export function decimalToNumber(value: Decimal | null | undefined): number {
+  return parseFloat(value?.toString() ?? '')
+}
+
+export function decimalToString(value: Decimal | null, defaultString: string = 'Missing'): string {
+  const converted = decimalToNumber(value)
+  if (isNaN(converted)) {
+    return defaultString
+  }
+  return converted.toString()
+}

--- a/public/dev-example-tmua.csv
+++ b/public/dev-example-tmua.csv
@@ -1,0 +1,2 @@
+cid,admissionsCycle,tmuaPaper1Score,tmuaPaper2Score,tmuaOverallScore
+12345678,2024,5,8,6.5


### PR DESCRIPTION
**UI**
- `TmuaGradeBox` displays TMUA grades in a table on Admin and UG tutor forms (hidden from reviewers)
  - <img width="612" alt="Screenshot 2024-10-02 at 14 22 11" src="https://github.com/user-attachments/assets/051e1090-a502-46e1-8ed9-cfe74e83d60b">

**Server**
- TMUA Grade upload actually updates TMUA grades (was a no-op placeholder before)
  - Example upload file: `public/dev-example-tmua.csv`
- Make `CandidateCallout` component to avoid duplication and complement
- `utils.ts` for Prisma Decimal -> TS number conversion