### PR TITLE
fix: explicitly order NextAction enum

### DIFF
--- a/components/ReviewerScoringDialog.tsx
+++ b/components/ReviewerScoringDialog.tsx
@@ -6,6 +6,7 @@ import GenericDialog from '@/components/GenericDialog'
 import LabelText from '@/components/LabelText'
 import { upsertReviewerScoring } from '@/lib/forms'
 import { FormPassbackState } from '@/lib/types'
+import { ord } from '@/lib/utils'
 import { NextAction } from '@prisma/client'
 import { Button, Callout, DataList, Flex, Text, TextField } from '@radix-ui/themes'
 import { format } from 'date-fns'
@@ -141,7 +142,7 @@ const ReviewerScoringDialog: FC<ReviewerScoringDialogProps> = ({ data, userEmail
         <Button
           color="jade"
           className="min-h-10"
-          disabled={data.nextAction < NextAction.REVIEWER_SCORING}
+          disabled={ord(data.nextAction) < ord(NextAction.REVIEWER_SCORING)}
         >
           Reviewer Scoring Form
         </Button>

--- a/lib/csv/upload.ts
+++ b/lib/csv/upload.ts
@@ -4,6 +4,7 @@ import prisma from '@/db'
 import { preprocessCsvData } from '@/lib/csv/preprocessing'
 import { parseWithSchema, schemaApplication, schemaTMUAScores, schemaUser } from '@/lib/csv/schema'
 import { allocateApplications } from '@/lib/reviewerAllocation'
+import { ord } from '@/lib/utils'
 import { Application, NextAction, Prisma, type User } from '@prisma/client'
 import { isNumber } from 'lodash'
 import { z } from 'zod'
@@ -63,7 +64,7 @@ function upsertApplication(applications: z.infer<typeof schemaApplication>[]) {
         ? NextAction.ADMIN_SCORING_WITH_TMUA
         : NextAction.ADMIN_SCORING_MISSING_TMUA
     // don't backtrack the application state
-    if (currentNextAction >= NextAction.REVIEWER_SCORING) return currentNextAction
+    if (ord(currentNextAction) >= ord(NextAction.REVIEWER_SCORING)) return currentNextAction
     if (currentNextAction === NextAction.PENDING_TMUA && isTmuaPresent)
       return NextAction.REVIEWER_SCORING
     if (currentNextAction === NextAction.ADMIN_SCORING_MISSING_TMUA && isTmuaPresent)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,3 +1,4 @@
+import { NextAction } from '@prisma/client'
 import { Decimal } from '@prisma/client/runtime/binary'
 
 // null and undefined are converted to NaN
@@ -11,4 +12,24 @@ export function decimalToString(value: Decimal | null, defaultString: string = '
     return defaultString
   }
   return converted.toString()
+}
+
+// Define a numerical order on Prisma enum, ordinarily done by string comparison
+export function ord(nextAction: NextAction): number {
+  switch (nextAction) {
+    case 'ADMIN_SCORING_MISSING_TMUA':
+      return 0
+    case 'ADMIN_SCORING_WITH_TMUA':
+      return 1
+    case 'PENDING_TMUA':
+      return 2
+    case 'REVIEWER_SCORING':
+      return 3
+    case 'UG_TUTOR_REVIEW':
+      return 4
+    case 'INFORM_CANDIDATE':
+      return 5
+    case 'CANDIDATE_INFORMED':
+      return 6
+  }
 }


### PR DESCRIPTION
Comparisons between Prisma enums are done by string content rather than the order constants are defined in, causing a bug in which states enabled the reviewer scoring button and updating logic. All greater than/less than comparisons between `NextAction` now use the `ord()` util which explicitly defines the order of the values.