### PR TITLE
fix: UG tutor form formatting and admin access

### DIFF
--- a/components/CommentItem.tsx
+++ b/components/CommentItem.tsx
@@ -1,7 +1,6 @@
 import { CommentType, Comment as PrismaComment } from '@prisma/client'
-import { Pencil2Icon } from '@radix-ui/react-icons'
 import { Badge, Card, Flex, Text } from '@radix-ui/themes'
-import { formatDistanceToNow } from 'date-fns'
+import { format } from 'date-fns'
 import { FC } from 'react'
 
 interface CommentProps {
@@ -17,26 +16,20 @@ const CommentTypeBadgeMap = {
 const CommentItem: FC<CommentProps> = ({ comment }) => {
   return (
     <Card>
-      <Flex>
-        <Flex className="basis-1/6">
-          <Pencil2Icon className="w-6 h-6" />
+      <Flex direction="column">
+        <Flex justify="between">
+          {CommentTypeBadgeMap[comment.type]}
+          <Text size="2" color="gray">
+            {format(new Date(comment.madeOn), 'HH:mm dd/MM/yyyy')}
+          </Text>
         </Flex>
-
-        <Flex className="basis-5/6" direction="column">
-          <Flex justify="between" align="center">
-            <Flex align="center" gap="2">
-              <Text weight="bold" size="3">
-                {comment.authorLogin}
-              </Text>
-              <Text size="1" weight="light">
-                {`${formatDistanceToNow(comment.madeOn)} ago`}
-              </Text>
-            </Flex>
-            {CommentTypeBadgeMap[comment.type]}
-          </Flex>
-          <Text size="2">{comment.text}</Text>
-        </Flex>
+        <Text weight="medium" size="3" className="ml-1">
+          {comment.authorLogin}
+        </Text>
       </Flex>
+      <Text size="2" className="ml-2">
+        {comment.text}
+      </Text>
     </Card>
   )
 }

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -38,7 +38,8 @@ type Tab = 'outcomes' | 'comments'
 
 interface UgTutorFormProps {
   data: ApplicationRow
-  readOnly: boolean
+  outcomesReadOnly: boolean
+  commentsReadOnly: boolean
   setCurrentTab: (tab: Tab) => void
 }
 
@@ -48,7 +49,12 @@ const decisionColourMap = {
   [Decision.PENDING]: 'bg-amber-200'
 }
 
-const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) => {
+const UgTutorForm: FC<UgTutorFormProps> = ({
+  data,
+  outcomesReadOnly,
+  commentsReadOnly,
+  setCurrentTab
+}) => {
   const { applicant, internalReview } = data
   const [outcomes, setOutcomes] = useState(data.outcomes)
   const [nextAction, setNextAction] = useState(data.nextAction.toString())
@@ -73,7 +79,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
       />
 
       {/* Reviewers should not be able to see TMUA grades */}
-      {!readOnly && (
+      {!commentsReadOnly && (
         <TmuaGradeBox
           paper1Score={data.tmuaPaper1Score}
           paper2Score={data.tmuaPaper2Score}
@@ -103,14 +109,14 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
                     <TextField.Root
                       name={'offerCode'.concat('-', outcome.degreeCode)}
                       defaultValue={outcome.offerCode ?? ''}
-                      disabled={readOnly}
+                      disabled={outcomesReadOnly}
                     />
                   </LabelText>
                   <LabelText label="Offer Text" weight="medium">
                     <TextField.Root
                       name={'offerText'.concat('-', outcome.degreeCode)}
                       defaultValue={outcome.offerText ?? ''}
-                      disabled={readOnly}
+                      disabled={outcomesReadOnly}
                     />
                   </LabelText>
                   <LabelText label="Decision" weight="medium">
@@ -124,7 +130,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
                           return newOutcomes
                         })
                       }}
-                      disabled={readOnly}
+                      disabled={outcomesReadOnly}
                       className="flex-grow"
                     />
                     <input
@@ -145,7 +151,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
                 ]}
                 currentValue={nextAction}
                 onValueChange={setNextAction}
-                disabled={readOnly}
+                disabled={outcomesReadOnly}
               />
             </LabelText>
             <input name="nextAction" type="hidden" value={nextAction} />
@@ -163,13 +169,13 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
                     values={Object.keys(CommentType)}
                     currentValue={commentType}
                     onValueChange={setCommentType}
-                    disabled={readOnly}
+                    disabled={commentsReadOnly}
                   />
                   <input name="type" type="hidden" value={commentType} />
                 </LabelText>
               </Flex>
               <LabelText label="Comment">
-                <TextArea name={'text'} defaultValue={''} disabled={readOnly} />
+                <TextArea name={'text'} defaultValue={''} disabled={commentsReadOnly} />
               </LabelText>
             </Flex>
           </Tabs.Content>
@@ -228,7 +234,12 @@ const UgTutorDialog: FC<UgTutorDialogProps> = ({ data, user }) => {
         onSuccess={handleFormSuccess}
         submitButtonText={currentTab === 'outcomes' ? 'Save' : 'Add Comment'}
       >
-        <UgTutorForm data={data} setCurrentTab={setCurrentTab} readOnly={role !== Role.UG_TUTOR} />
+        <UgTutorForm
+          data={data}
+          outcomesReadOnly={role !== Role.UG_TUTOR}
+          commentsReadOnly={role !== Role.UG_TUTOR && role !== Role.ADMIN}
+          setCurrentTab={setCurrentTab}
+        />
       </FormWrapper>
     </GenericDialog>
   )


### PR DESCRIPTION
Formatting fix for UG tutor form and admins can now leave comments on the UG tutor form (still unable to assign outcomes and next action)

![Screenshot 2024-10-09 at 15 40 03](https://github.com/user-attachments/assets/8ed90379-c84f-4683-8f34-8f50800df00c)

