### PR TITLE
feat: admin workflow

### DIFF
--- a/components/ApplicationTable.tsx
+++ b/components/ApplicationTable.tsx
@@ -4,6 +4,7 @@ import AdminScoringDialog from '@/components/AdminScoringDialog'
 import ReviewerScoringDialog from '@/components/ReviewerScoringDialog'
 import TanstackTable from '@/components/TanstackTable'
 import UgTutorDialog from '@/components/UgTutorDialog'
+import { updateNextAction } from '@/lib/forms'
 import { prettifyOption, prettifyReviewerEmail } from '@/lib/utils'
 import {
   Applicant,
@@ -17,8 +18,8 @@ import {
   User,
   WP
 } from '@prisma/client'
-import { MagnifyingGlassIcon } from '@radix-ui/react-icons'
-import { Card, Flex, Text, TextField } from '@radix-ui/themes'
+import { CheckboxIcon, MagnifyingGlassIcon } from '@radix-ui/react-icons'
+import { Button, Card, Flex, Text, TextField } from '@radix-ui/themes'
 import { ColumnFiltersState, createColumnHelper } from '@tanstack/react-table'
 import { useSession } from 'next-auth/react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
@@ -123,7 +124,9 @@ const ApplicationTable: FC<ApplicationTableProps> = ({
       id: 'wideningParticipation'
     }),
     columnHelper.accessor('nextAction', {
-      cell: (info) => prettifyOption(info.getValue()),
+      cell: (info) => (
+        <NextActionCell nextAction={info.getValue()} applicationId={info.row.original.id} />
+      ),
       header: 'Next Action',
       id: SEARCH_PARAM_NEXT_ACTION
     }),
@@ -206,6 +209,29 @@ const WPColourMap: Record<WP, 'green' | 'red' | 'yellow'> = {
   [WP.YES]: 'green',
   [WP.NO]: 'red',
   [WP.NOT_CALCULATED]: 'yellow'
+}
+
+const NextActionCell: FC<{ nextAction: NextAction; applicationId: number }> = ({
+  nextAction,
+  applicationId
+}) => {
+  return (
+    <Flex align="center" justify="between" gap="2">
+      {prettifyOption(nextAction)}
+      {nextAction === NextAction.INFORM_CANDIDATE && (
+        <Button
+          size="1"
+          color="grass"
+          onClick={() => {
+            updateNextAction(NextAction.CANDIDATE_INFORMED, applicationId)
+            window.location.reload()
+          }}
+        >
+          <CheckboxIcon />
+        </Button>
+      )}
+    </Flex>
+  )
 }
 
 export default ApplicationTable

--- a/components/CommentItem.tsx
+++ b/components/CommentItem.tsx
@@ -10,7 +10,8 @@ interface CommentProps {
 const CommentTypeBadgeMap = {
   [CommentType.NOTE]: <Badge color="orange">Note</Badge>,
   [CommentType.CANDIDATE_CHANGE_REQUEST]: <Badge color="blue">Candidate Change Request</Badge>,
-  [CommentType.OFFER_CONDITION]: <Badge color="green">Offer Condition</Badge>
+  [CommentType.OFFER_CONDITION]: <Badge color="green">Offer Condition</Badge>,
+  [CommentType.AMEND_OFFER]: <Badge color="red">Amend Offer</Badge>
 }
 
 const CommentItem: FC<CommentProps> = ({ comment }) => {

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -53,7 +53,7 @@ const decisionColourMap = {
 const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) => {
   const { applicant, internalReview } = data
   const [outcomes, setOutcomes] = useState(data.outcomes)
-  const [nextAction, setNextAction] = useState(data.nextAction.toString())
+  const [nextAction, setNextAction] = useState('Unchanged')
   const [commentType, setCommentType] = useState(CommentType.NOTE.toString())
 
   // sort comments in descending order (most recent)
@@ -132,19 +132,6 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
                 </Flex>
               </Card>
             ))}
-            <LabelText label="Set Next Action">
-              <Dropdown
-                values={[
-                  NextAction.UG_TUTOR_REVIEW,
-                  NextAction.INFORM_CANDIDATE,
-                  NextAction.CANDIDATE_INFORMED
-                ]}
-                currentValue={nextAction}
-                onValueChange={setNextAction}
-                disabled={readOnly}
-              />
-            </LabelText>
-            <input name="nextAction" type="hidden" value={nextAction} />
           </Tabs.Content>
 
           <Tabs.Content value="comments">
@@ -169,6 +156,21 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
               </LabelText>
             </Flex>
           </Tabs.Content>
+
+          <LabelText label="Set Next Action" className="mt-2">
+            <Dropdown
+              values={[
+                'Unchanged',
+                NextAction.UG_TUTOR_REVIEW,
+                NextAction.INFORM_CANDIDATE,
+                NextAction.CANDIDATE_INFORMED
+              ]}
+              currentValue={nextAction}
+              onValueChange={setNextAction}
+              disabled={readOnly}
+            />
+          </LabelText>
+          <input name="nextAction" type="hidden" value={nextAction} />
         </Box>
       </Tabs.Root>
     </Flex>
@@ -198,7 +200,7 @@ const UgTutorDialog: FC<UgTutorDialogProps> = ({ data, user }) => {
   const addCommentWithId = async (prevState: FormPassbackState, formData: FormData) => {
     if (!internalReview)
       return { status: 'error', message: 'Admin scoring form must be completed first!' }
-    return await insertComment(admissionsCycle, email, internalReview.id, prevState, formData)
+    return await insertComment(id, admissionsCycle, email, internalReview.id, prevState, formData)
   }
 
   return (

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -6,7 +6,7 @@ import FormWrapper from '@/components/FormWrapper'
 import GenericDialog from '@/components/GenericDialog'
 import LabelText from '@/components/LabelText'
 import TmuaGradeBox from '@/components/TmuaGradeBox'
-import { adminAccess, ugTutorOutcomeAccess } from '@/lib/access'
+import { adminAccess } from '@/lib/access'
 import { insertComment, upsertOutcome } from '@/lib/forms'
 import { FormPassbackState } from '@/lib/types'
 import {
@@ -40,8 +40,7 @@ type Tab = 'outcomes' | 'comments'
 
 interface UgTutorFormProps {
   data: ApplicationRow
-  outcomesReadOnly: boolean
-  commentsReadOnly: boolean
+  readOnly: boolean
   setCurrentTab: (tab: Tab) => void
 }
 
@@ -51,12 +50,7 @@ const decisionColourMap = {
   [Decision.PENDING]: 'bg-amber-200'
 }
 
-const UgTutorForm: FC<UgTutorFormProps> = ({
-  data,
-  outcomesReadOnly,
-  commentsReadOnly,
-  setCurrentTab
-}) => {
+const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) => {
   const { applicant, internalReview } = data
   const [outcomes, setOutcomes] = useState(data.outcomes)
   const [nextAction, setNextAction] = useState(data.nextAction.toString())
@@ -81,7 +75,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
       />
 
       {/* Reviewers should not be able to see TMUA grades */}
-      {!commentsReadOnly && <TmuaGradeBox score={data.tmuaScore} />}
+      {!readOnly && <TmuaGradeBox score={data.tmuaScore} />}
 
       <Tabs.Root defaultValue="outcomes" onValueChange={(tabName) => setCurrentTab(tabName as Tab)}>
         <Tabs.List>
@@ -112,7 +106,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
                           return newOutcomes
                         })
                       }}
-                      disabled={outcomesReadOnly}
+                      disabled={readOnly}
                       className="flex-grow"
                     />
                     <input
@@ -125,14 +119,14 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
                     <TextField.Root
                       name={'offerCode'.concat('-', outcome.degreeCode)}
                       defaultValue={outcome.offerCode ?? ''}
-                      disabled={outcomesReadOnly}
+                      disabled={readOnly}
                     />
                   </LabelText>
                   <LabelText label="Offer Text" weight="medium">
                     <TextField.Root
                       name={'offerText'.concat('-', outcome.degreeCode)}
                       defaultValue={outcome.offerText ?? ''}
-                      disabled={outcomesReadOnly}
+                      disabled={readOnly}
                     />
                   </LabelText>
                 </Flex>
@@ -147,7 +141,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
                 ]}
                 currentValue={nextAction}
                 onValueChange={setNextAction}
-                disabled={outcomesReadOnly}
+                disabled={readOnly}
               />
             </LabelText>
             <input name="nextAction" type="hidden" value={nextAction} />
@@ -165,13 +159,13 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
                     values={Object.keys(CommentType)}
                     currentValue={commentType}
                     onValueChange={setCommentType}
-                    disabled={commentsReadOnly}
+                    disabled={readOnly}
                   />
                   <input name="type" type="hidden" value={commentType} />
                 </LabelText>
               </Flex>
               <LabelText label="Comment">
-                <TextArea name={'text'} defaultValue={''} disabled={commentsReadOnly} />
+                <TextArea name="text" defaultValue="" disabled={readOnly} />
               </LabelText>
             </Flex>
           </Tabs.Content>
@@ -226,8 +220,7 @@ const UgTutorDialog: FC<UgTutorDialogProps> = ({ data, user }) => {
       >
         <UgTutorForm
           data={data}
-          outcomesReadOnly={!ugTutorOutcomeAccess(email, role)}
-          commentsReadOnly={!adminAccess(email, role)}
+          readOnly={!adminAccess(email, role)}
           setCurrentTab={setCurrentTab}
         />
       </FormWrapper>

--- a/lib/access.ts
+++ b/lib/access.ts
@@ -13,7 +13,3 @@ export function reviewerAccess(reviewerEmail: string | undefined, userEmail: str
   // only the assigned reviewer
   return reviewerEmail === userEmail
 }
-
-export function ugTutorOutcomeAccess(userEmail: string, userRole?: Role): boolean {
-  return isSuperUser(userEmail) || userRole === Role.UG_TUTOR
-}

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -170,10 +170,13 @@ export const insertComment = async (
   return { status: 'success', message: 'UG tutor form added comment successfully.' }
 }
 
-async function updateNextAction(nextActionForm: FormDataEntryValue | null, applicationId: number) {
-  if (!nextActionForm || nextActionForm === 'Unchanged') return
+export async function updateNextAction(
+  nextActionInput: FormDataEntryValue | string | null,
+  applicationId: number
+) {
+  if (!nextActionInput || nextActionInput === 'Unchanged') return
 
-  const nextAction = nextActionField.parse(nextActionForm)
+  const nextAction = nextActionField.parse(nextActionInput)
   await prisma.application.update({
     where: { id: applicationId },
     data: {

--- a/lib/forms.ts
+++ b/lib/forms.ts
@@ -126,13 +126,7 @@ export const upsertOutcome = async (
     return { id, ...parsedOutcome }
   })
 
-  const nextAction = nextActionField.parse(formData.get('nextAction'))
-  await prisma.application.update({
-    where: { id: applicationId },
-    data: {
-      nextAction
-    }
-  })
+  await updateNextAction(formData.get('nextAction'), applicationId)
 
   for (const { id, offerCode, offerText, decision } of groupedOutcomes) {
     await prisma.outcome.update({
@@ -150,16 +144,19 @@ export const upsertOutcome = async (
 }
 
 export const insertComment = async (
+  applicationId: number,
   admissionsCycle: number,
-  ugTutorEmail: string,
+  authorEmail: string,
   internalReviewId: number,
   _: FormPassbackState,
   formData: FormData
 ): Promise<FormPassbackState> => {
-  formData.set('authorLogin', ugTutorEmail)
+  formData.set('authorLogin', authorEmail)
 
   const result = formCommentSchema.safeParse(Object.fromEntries(formData))
   if (!result.success) return { status: 'error', message: result.error.issues[0].message }
+
+  await updateNextAction(formData.get('nextAction'), applicationId)
 
   await prisma.comment.create({
     data: {
@@ -171,4 +168,16 @@ export const insertComment = async (
 
   revalidatePath('/')
   return { status: 'success', message: 'UG tutor form added comment successfully.' }
+}
+
+async function updateNextAction(nextActionForm: FormDataEntryValue | null, applicationId: number) {
+  if (!nextActionForm || nextActionForm === 'Unchanged') return
+
+  const nextAction = nextActionField.parse(nextActionForm)
+  await prisma.application.update({
+    where: { id: applicationId },
+    data: {
+      nextAction
+    }
+  })
 }

--- a/prisma/migrations/20241028132712_add_amend_offer_comment_type/migration.sql
+++ b/prisma/migrations/20241028132712_add_amend_offer_comment_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "CommentType" ADD VALUE 'AMEND_OFFER';

--- a/prisma/schema/comment.prisma
+++ b/prisma/schema/comment.prisma
@@ -2,6 +2,7 @@ enum CommentType {
   NOTE
   CANDIDATE_CHANGE_REQUEST
   OFFER_CONDITION
+  AMEND_OFFER
 }
 
 model Comment {


### PR DESCRIPTION
- Admins and UG tutor now have the same access permissions for editing etc.
- Candidates in _Inform Candidate_ can be easily moved to _Candidate Informed_ from the application table by clicking a button
  - <img width="1416" alt="Screenshot 2024-10-28 at 16 05 24" src="https://github.com/user-attachments/assets/64db7952-349f-4d38-bb26-bb2b1f48252f">
- New type of comment: `Amend Offer` and comments can update next action or leave `Unchanged`
  - <img width="612" alt="Screenshot 2024-10-28 at 16 04 57" src="https://github.com/user-attachments/assets/f17b1849-196f-4135-b139-c2d4733a4777">
