### PR TITLE
fix: missing outcomes and insertion errors

### DIFF
--- a/components/AdminScoringDialog.tsx
+++ b/components/AdminScoringDialog.tsx
@@ -11,7 +11,7 @@ import { upsertAdminScoring } from '@/lib/forms'
 import { FormPassbackState } from '@/lib/types'
 import { decimalToNumber } from '@/lib/utils'
 import { AlevelQualification, GCSEQualification, Role } from '@prisma/client'
-import { FileTextIcon, IdCardIcon } from '@radix-ui/react-icons'
+import { IdCardIcon } from '@radix-ui/react-icons'
 import { Button, Flex, Heading, Popover, Text, TextField } from '@radix-ui/themes'
 import { format } from 'date-fns'
 import React, { FC, useState } from 'react'
@@ -67,22 +67,6 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
               </Popover.Trigger>
               <Popover.Content className="bg-yellow-50">
                 <Text>{data.extenuatingCircumstances}</Text>
-              </Popover.Content>
-            </Popover.Root>
-          )}
-        </Flex>
-
-        <Flex direction="column" gap="2">
-          {data.academicEligibilityNotes && (
-            <Popover.Root>
-              <Popover.Trigger>
-                <Button type="button" variant="soft" color="yellow">
-                  <FileTextIcon width={ICON_SIZE} height={ICON_SIZE} />
-                  Academic eligibility notes
-                </Button>
-              </Popover.Trigger>
-              <Popover.Content className="bg-yellow-50">
-                <Text>{data.academicEligibilityNotes}</Text>
               </Popover.Content>
             </Popover.Root>
           )}

--- a/components/UgTutorDialog.tsx
+++ b/components/UgTutorDialog.tsx
@@ -25,6 +25,7 @@ import {
   Heading,
   Separator,
   Tabs,
+  Text,
   TextArea,
   TextField
 } from '@radix-ui/themes'
@@ -90,45 +91,53 @@ const UgTutorForm: FC<UgTutorFormProps> = ({ data, readOnly, setCurrentTab }) =>
                 key={outcome.id}
                 className={`my-2 ${decisionColourMap[outcome.decision]}`}
                 variant="classic"
-                size={'2'}
+                size="2"
               >
-                <Heading size={'3'}>{outcome.degreeCode}</Heading>
-                <Separator className="w-full my-1" />
-                <Flex direction="column" gap="3">
-                  <LabelText label="Decision" weight="medium">
-                    <Dropdown
-                      values={Object.keys(Decision)}
-                      currentValue={outcome.decision}
-                      onValueChange={(newDecision) => {
-                        setOutcomes((prevOutcomes) => {
-                          const newOutcomes = [...prevOutcomes]
-                          newOutcomes[i].decision = newDecision as Decision
-                          return newOutcomes
-                        })
-                      }}
-                      disabled={readOnly}
-                      className="flex-grow"
-                    />
-                    <input
-                      name={'decision'.concat('-', outcome.degreeCode)}
-                      type="hidden"
-                      value={outcome.decision.toString()}
-                    />
-                  </LabelText>
-                  <LabelText label="Offer Code" weight="medium">
-                    <TextField.Root
-                      name={'offerCode'.concat('-', outcome.degreeCode)}
-                      defaultValue={outcome.offerCode ?? ''}
-                      disabled={readOnly}
-                    />
-                  </LabelText>
-                  <LabelText label="Offer Text" weight="medium">
-                    <TextField.Root
-                      name={'offerText'.concat('-', outcome.degreeCode)}
-                      defaultValue={outcome.offerText ?? ''}
-                      disabled={readOnly}
-                    />
-                  </LabelText>
+                <Flex direction="column" gap="1">
+                  <Heading size="3">{outcome.degreeCode}</Heading>
+                  <Flex gap="1">
+                    <Text size="2" weight="medium">
+                      Academic eligibility:
+                    </Text>
+                    <Text size="2">{outcome.academicEligibilityNotes}</Text>
+                  </Flex>
+                  <Separator className="w-full my-1" />
+                  <Flex direction="column" gap="3">
+                    <LabelText label="Decision" weight="medium">
+                      <Dropdown
+                        values={Object.keys(Decision)}
+                        currentValue={outcome.decision}
+                        onValueChange={(newDecision) => {
+                          setOutcomes((prevOutcomes) => {
+                            const newOutcomes = [...prevOutcomes]
+                            newOutcomes[i].decision = newDecision as Decision
+                            return newOutcomes
+                          })
+                        }}
+                        disabled={readOnly}
+                        className="flex-grow"
+                      />
+                      <input
+                        name={'decision'.concat('-', outcome.degreeCode)}
+                        type="hidden"
+                        value={outcome.decision.toString()}
+                      />
+                    </LabelText>
+                    <LabelText label="Offer Code" weight="medium">
+                      <TextField.Root
+                        name={'offerCode'.concat('-', outcome.degreeCode)}
+                        defaultValue={outcome.offerCode ?? ''}
+                        disabled={readOnly}
+                      />
+                    </LabelText>
+                    <LabelText label="Offer Text" weight="medium">
+                      <TextField.Root
+                        name={'offerText'.concat('-', outcome.degreeCode)}
+                        defaultValue={outcome.offerText ?? ''}
+                        disabled={readOnly}
+                      />
+                    </LabelText>
+                  </Flex>
                 </Flex>
               </Card>
             ))}

--- a/lib/csv/preprocessing.ts
+++ b/lib/csv/preprocessing.ts
@@ -77,9 +77,9 @@ function processApplication(
 
   for (const row of df.toCollection()) {
     if (applicantMap.has(row.cid)) {
-      // only need to add a degree
+      // only need to add a course
       const existing = applicantMap.get(row.cid)
-      existing?.degrees.push({
+      existing?.courses.push({
         degreeCode: row.degreeCode,
         academicEligibilityNotes: row.academicEligibilityNotes
       })
@@ -95,7 +95,7 @@ function processApplication(
         email: row.email,
         primaryNationality: row.primaryNationality
       }
-      const degrees = [
+      const courses = [
         {
           degreeCode: row.degreeCode,
           academicEligibilityNotes: row.academicEligibilityNotes
@@ -110,7 +110,7 @@ function processApplication(
         tmuaScore: row.tmuaScore,
         extenuatingCircumstances: row.extenuatingCircumstances
       }
-      applicantMap.set(row.cid, { applicant, degrees, application })
+      applicantMap.set(row.cid, { applicant, courses, application })
     }
   }
 

--- a/lib/csv/preprocessing.ts
+++ b/lib/csv/preprocessing.ts
@@ -1,6 +1,8 @@
+import { csvApplicationSchema } from '@/lib/schema'
 import { DataUploadEnum } from '@/lib/types'
 import { CsvError, parse } from 'csv-parse/sync'
 import DataFrame from 'dataframe-js'
+import { z } from 'zod'
 
 /**
  * Parses a CSV and runs processing function according to the upload type
@@ -59,111 +61,60 @@ export async function preprocessCsvData(
  * @param cycle
  * @returns an array of objects with nested applicant and application objects
  */
-function processApplication(objects: unknown[], cycle: number): unknown[] {
+function processApplication(
+  objects: unknown[],
+  cycle: number
+): z.infer<typeof csvApplicationSchema>[] {
   let df = new DataFrame(objects)
   df = df.replace('', null)
-
-  df = renameColumns(df, [
-    ['College ID (Applicant) (Contact)', 'cid'],
-    ['UCAS ID (Applicant) (Contact)', 'ucasNumber'],
-    ['Programme code (Programme) (Programme)', 'degreeCode'],
-    ['First name (Applicant) (Contact)', 'firstName'],
-    ['Last name (Applicant) (Contact)', 'surname'],
-    ['Nationality (Applicant) (Contact)', 'primaryNationality'],
-    ['Primary email address (Applicant) (Contact)', 'email'],
-    ['Gender (Applicant) (Contact)', 'gender'],
-    ['Date of birth', 'dateOfBirth'],
-    ['Preferred first name (Applicant) (Contact)', 'preferredName'],
-    ['Entry term', 'entryYear'],
-    ['Fee status', 'feeStatus'],
-    ['WP flag', 'wideningParticipation'],
-    ['Sent to department', 'applicationDate'],
-    ['Extenuating circumstances notes', 'extenuatingCircumstances'],
-    ['Academic eligibility notes', 'academicEligibilityNotes'],
-    ['TMUA Score', 'tmuaScore']
-  ])
-
+  df = renameApplicationColumns(df)
   df = padCidWith0s(df)
   df = addAdmissionsCycle(df, cycle)
+  df = transformDataFormats(df)
 
-  // @ts-ignore
-  df = df.withColumn('entryYear', (row: any) => {
-    // format is 'Autumn 2025-2026' so extract '2526'
-    const [year1, year2] = row.get('entryYear')?.split(' ').at(1)?.split('-')
-    return year1.slice(-2) + year2.slice(-2)
-  })
+  // map from cid to object with applicant, degrees and application
+  const applicantMap = new Map<string, z.infer<typeof csvApplicationSchema>>()
 
-  df = df.withColumn(
-    'degreeCode',
-    // @ts-ignore
-    (row: any) =>
-      // format is G400.1 so remove the .1
-      row.get('degreeCode')?.split('.').at(0)
-  )
+  for (const row of df.toCollection()) {
+    if (applicantMap.has(row.cid)) {
+      // only need to add a degree
+      const existing = applicantMap.get(row.cid)
+      existing?.degrees.push({
+        degreeCode: row.degreeCode,
+        academicEligibilityNotes: row.academicEligibilityNotes
+      })
+    } else {
+      const applicant = {
+        cid: row.cid,
+        ucasNumber: row.ucasNumber,
+        gender: row.gender,
+        firstName: row.firstName,
+        surname: row.surname,
+        preferredName: row.preferredName,
+        dateOfBirth: row.dateOfBirth,
+        email: row.email,
+        primaryNationality: row.primaryNationality
+      }
+      const degrees = [
+        {
+          degreeCode: row.degreeCode,
+          academicEligibilityNotes: row.academicEligibilityNotes
+        }
+      ]
+      const application = {
+        admissionsCycle: row.admissionsCycle,
+        entryYear: row.entryYear,
+        feeStatus: row.feeStatus,
+        wideningParticipation: row.wideningParticipation,
+        applicationDate: row.applicationDate,
+        tmuaScore: row.tmuaScore,
+        extenuatingCircumstances: row.extenuatingCircumstances
+      }
+      applicantMap.set(row.cid, { applicant, degrees, application })
+    }
+  }
 
-  // capitalise enums so they validate
-  // @ts-ignore
-  df = df.withColumn('gender', (row: any) => {
-    const gender = row.get('gender')
-    if (gender === 'Other gender not listed') return 'OTHER'
-    return gender?.toUpperCase()
-  })
-  // @ts-ignore
-  df = df.withColumn('wideningParticipation', (row: any) => {
-    const wp = row.get('wideningParticipation')
-    if (wp === 'Not calculated') return 'NOT_CALCULATED'
-    return wp?.toUpperCase()
-  })
-  // @ts-ignore
-  df = df.withColumn('feeStatus', (row: any) => {
-    const feeStatus = row.get('feeStatus')
-    if (feeStatus === 'Query') return 'UNKNOWN'
-    return feeStatus?.toUpperCase()
-  })
-
-  const applicantColumns = [
-    'cid',
-    'ucasNumber',
-    'gender',
-    'firstName',
-    'surname',
-    'preferredName',
-    'dateOfBirth',
-    'email',
-    'primaryNationality'
-  ]
-  const applicantDf = df.select(...applicantColumns)
-  const applicantObjects = applicantDf.toCollection()
-
-  const applicationColumns = [
-    'hasDisability',
-    'admissionsCycle',
-    'entryYear',
-    'feeStatus',
-    'wideningParticipation',
-    'applicationDate',
-    'tmuaScore',
-    'extenuatingCircumstances',
-    'academicEligibilityNotes'
-  ]
-
-  // filter in case columns are missing e.g. TMUA score
-  const existingApplicationColumns = applicationColumns.filter((col) =>
-    df.listColumns().includes(col)
-  )
-  const applicationDf = df.select(...existingApplicationColumns)
-  const applicationObjects = applicationDf.toCollection()
-
-  const outcomeColumns = ['degreeCode']
-  const outcomeDf = df.select(...outcomeColumns)
-  const outcomeObjects = outcomeDf.toCollection()
-
-  // zip arrays together to create nested object for schema validation
-  return applicantObjects.map((applicant: unknown, i: number) => ({
-    applicant: applicant,
-    application: applicationObjects[i],
-    outcome: outcomeObjects[i]
-  }))
+  return Array.from(applicantMap.values())
 }
 
 function processTMUAScores(objects: unknown[], cycle: number): unknown[] {
@@ -180,16 +131,7 @@ function processTMUAScores(objects: unknown[], cycle: number): unknown[] {
 
 function processAdminScoring(objects: unknown[], cycle: number): unknown[] {
   let df = new DataFrame(objects)
-  df = renameColumns(df, [
-    ['CID', 'cid'],
-    ['Age 16 Qualification Type', 'gcseQualification'],
-    ['Age 16 Qualification Score', 'gcseQualificationScore'],
-    ['Age 18 Qualification Type', 'aLevelQualification'],
-    ['Age 18 Qualification Score', 'aLevelQualificationScore'],
-    ['Motivation Score', 'motivationAdminScore'],
-    ['Extracurricular Score', 'extracurricularAdminScore'],
-    ['Exam Comments', 'examComments']
-  ])
+  df = renameAdminScoringColumns(df)
   df = padCidWith0s(df)
   df = addAdmissionsCycle(df, cycle)
   return df.toCollection()
@@ -221,5 +163,77 @@ function padCidWith0s(df: DataFrame): DataFrame {
   // @ts-ignore
   return df.withColumn('cid', (row: any) => {
     return row.get('cid')?.padStart(8, '0')
+  })
+}
+
+function renameApplicationColumns(df: DataFrame): DataFrame {
+  return renameColumns(df, [
+    ['College ID (Applicant) (Contact)', 'cid'],
+    ['UCAS ID (Applicant) (Contact)', 'ucasNumber'],
+    ['Programme code (Programme) (Programme)', 'degreeCode'],
+    ['First name (Applicant) (Contact)', 'firstName'],
+    ['Last name (Applicant) (Contact)', 'surname'],
+    ['Nationality (Applicant) (Contact)', 'primaryNationality'],
+    ['Primary email address (Applicant) (Contact)', 'email'],
+    ['Gender (Applicant) (Contact)', 'gender'],
+    ['Date of birth', 'dateOfBirth'],
+    ['Preferred first name (Applicant) (Contact)', 'preferredName'],
+    ['Entry term', 'entryYear'],
+    ['Fee status', 'feeStatus'],
+    ['WP flag', 'wideningParticipation'],
+    ['Sent to department', 'applicationDate'],
+    ['Extenuating circumstances notes', 'extenuatingCircumstances'],
+    ['Academic eligibility notes', 'academicEligibilityNotes'],
+    ['TMUA Score', 'tmuaScore']
+  ])
+}
+
+function renameAdminScoringColumns(df: DataFrame): DataFrame {
+  return renameColumns(df, [
+    ['CID', 'cid'],
+    ['Age 16 Qualification Type', 'gcseQualification'],
+    ['Age 16 Qualification Score', 'gcseQualificationScore'],
+    ['Age 18 Qualification Type', 'aLevelQualification'],
+    ['Age 18 Qualification Score', 'aLevelQualificationScore'],
+    ['Motivation Score', 'motivationAdminScore'],
+    ['Extracurricular Score', 'extracurricularAdminScore'],
+    ['Exam Comments', 'examComments']
+  ])
+}
+
+function transformDataFormats(df: DataFrame): DataFrame {
+  // @ts-ignore
+  df = df.withColumn('entryYear', (row: any) => {
+    // format is 'Autumn 2025-2026' so extract '2526'
+    const [year1, year2] = row.get('entryYear')?.split(' ').at(1)?.split('-')
+    return year1.slice(-2) + year2.slice(-2)
+  })
+
+  df = df.withColumn(
+    'degreeCode',
+    // @ts-ignore
+    (row: any) =>
+      // format is G400.1 so remove the .1
+      row.get('degreeCode')?.split('.').at(0)
+  )
+
+  // capitalise enums so they validate
+  // @ts-ignore
+  df = df.withColumn('gender', (row: any) => {
+    const gender = row.get('gender')
+    if (gender === 'Other gender not listed') return 'OTHER'
+    return gender?.toUpperCase()
+  })
+  // @ts-ignore
+  df = df.withColumn('wideningParticipation', (row: any) => {
+    const wp = row.get('wideningParticipation')
+    if (wp === 'Not calculated') return 'NOT_CALCULATED'
+    return wp?.toUpperCase()
+  })
+  // @ts-ignore
+  return df.withColumn('feeStatus', (row: any) => {
+    const feeStatus = row.get('feeStatus')
+    if (feeStatus === 'Query') return 'UNKNOWN'
+    return feeStatus?.toUpperCase()
   })
 }

--- a/lib/csv/upload.ts
+++ b/lib/csv/upload.ts
@@ -53,7 +53,7 @@ async function getCurrentNextAction(
 }
 
 function upsertApplicant(applicants: z.infer<typeof csvApplicationSchema>[]) {
-  return applicants.map(async ({ applicant, courses, application }) => {
+  return applicants.map(async ({ applicant }) => {
     return prisma.applicant.upsert({
       where: {
         cid: applicant.cid

--- a/lib/csv/upload.ts
+++ b/lib/csv/upload.ts
@@ -93,6 +93,7 @@ function upsertOutcome(outcomes: z.infer<typeof csvApplicationSchema>[]) {
     })
   })
 }
+
 function upsertApplication(applications: z.infer<typeof csvApplicationSchema>[]) {
   function calculateNextAction(currentNextAction: NextAction | undefined, isTmuaPresent: boolean) {
     if (!currentNextAction)
@@ -303,7 +304,12 @@ export const processCsvUpload = async (
       return { status: 'error', message: outcomeResult.errorMessage }
     }
     // application allocation briefly disabled
-    return { status: 'success', message: `All applications entered successfully` }
+    const numApplicants = applicantResult.fulfilledUpserts?.length
+    const numOutcomes = outcomeResult.fulfilledUpserts?.length
+    return {
+      status: 'success',
+      message: `Successfully input ${numApplicants} applicants applying for ${numOutcomes} courses`
+    }
   } else if (dataUploadType === DataUploadEnum.TMUA_SCORES) {
     const tmuaScoresResult = await createAndExecutePromises(
       objects,

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -84,7 +84,7 @@ export const csvApplicationSchema = z.object({
     email: z.string().email(),
     primaryNationality: z.string()
   }),
-  degrees: z.array(
+  courses: z.array(
     z.object({
       degreeCode: z.nativeEnum(DegreeCode),
       academicEligibilityNotes: z.string().nullable()

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -84,6 +84,12 @@ export const csvApplicationSchema = z.object({
     email: z.string().email(),
     primaryNationality: z.string()
   }),
+  degrees: z.array(
+    z.object({
+      degreeCode: z.nativeEnum(DegreeCode),
+      academicEligibilityNotes: z.string().nullable()
+    })
+  ),
   application: z.object({
     admissionsCycle: cycleField,
     entryYear: cycleField,
@@ -100,11 +106,7 @@ export const csvApplicationSchema = z.object({
       })
       .nullable(),
     tmuaScore: z.coerce.number().min(1).max(9).optional(),
-    extenuatingCircumstances: z.string().nullable(),
-    academicEligibilityNotes: z.string().nullable()
-  }),
-  outcome: z.object({
-    degreeCode: z.nativeEnum(DegreeCode)
+    extenuatingCircumstances: z.string().nullable()
   })
 })
 

--- a/prisma/migrations/20241115170025_add_academic_eligibility_notes_to_outcome/migration.sql
+++ b/prisma/migrations/20241115170025_add_academic_eligibility_notes_to_outcome/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Outcome"
+    ADD COLUMN "academicEligibilityNotes" TEXT;

--- a/prisma/migrations/20241115190633_remove_academic_elig_from_application/migration.sql
+++ b/prisma/migrations/20241115190633_remove_academic_elig_from_application/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `academicEligibilityNotes` on the `Application` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Application"
+    DROP COLUMN "academicEligibilityNotes";

--- a/prisma/schema/application.prisma
+++ b/prisma/schema/application.prisma
@@ -57,7 +57,6 @@ model Application {
   aLevelQualification      AlevelQualification?
   aLevelQualificationScore Decimal?             @db.Decimal(3, 1)
   extenuatingCircumstances String?
-  academicEligibilityNotes String?
   /// internalReview contains all scores and comments from admins, reviewers and UG tutors
   internalReview           InternalReview?
   /// nextAction is an enum referring to the action pending completion for the application to progress

--- a/prisma/schema/outcome.prisma
+++ b/prisma/schema/outcome.prisma
@@ -20,14 +20,15 @@ enum DegreeCode {
 }
 
 model Outcome {
-  id              Int         @id @default(autoincrement())
-  application     Application @relation(fields: [cid, admissionsCycle], references: [cid, admissionsCycle])
-  cid             String
-  admissionsCycle Int
-  degreeCode      DegreeCode
-  decision        Decision    @default(PENDING)
-  offerCode       String?
-  offerText       String?
+  id                       Int         @id @default(autoincrement())
+  application              Application @relation(fields: [cid, admissionsCycle], references: [cid, admissionsCycle])
+  cid                      String
+  admissionsCycle          Int
+  degreeCode               DegreeCode
+  academicEligibilityNotes String?
+  decision                 Decision    @default(PENDING)
+  offerCode                String?
+  offerText                String?
 
   @@unique(fields: [cid, admissionsCycle, degreeCode], name: "cid_cycle_degree")
 }


### PR DESCRIPTION
Now upsert applicants, applications and outcomes sequentially to avoid Prisma race conditions when executing all promises together. Pre-process the data to aggregate all courses applied within each applicant. Academic eligibility notes are per course now rather than the whole application.