### PR TITLE
feat: add timestamp for last edit in UG tutor form

### DIFF
--- a/components/dialog/AdminScoringDialog.tsx
+++ b/components/dialog/AdminScoringDialog.tsx
@@ -7,6 +7,7 @@ import TmuaGradeBox from '@/components/dialog/TmuaGradeBox'
 import Dropdown from '@/components/general/Dropdown'
 import LabelText from '@/components/general/LabelText'
 import { adminAccess } from '@/lib/access'
+import { dateFormatting } from '@/lib/constants'
 import { upsertAdminScoring } from '@/lib/query/forms'
 import { FormPassbackState } from '@/lib/types'
 import { decimalToNumber } from '@/lib/utils'
@@ -42,7 +43,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
       {internalReview?.lastAdminEditOn && internalReview?.lastAdminEditBy && (
         <Text size="2" className="italic text-gray-500">
           Last edited by {internalReview.lastAdminEditBy} on{' '}
-          {format(internalReview.lastAdminEditOn, "dd/MM/yy 'at' HH:mm")}
+          {format(internalReview.lastAdminEditOn, dateFormatting)}
         </Text>
       )}
 

--- a/components/dialog/AdminScoringDialog.tsx
+++ b/components/dialog/AdminScoringDialog.tsx
@@ -42,7 +42,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
     <Flex direction="column" gap="3">
       {internalReview?.lastAdminEditOn && internalReview?.lastAdminEditBy && (
         <Text size="2" className="italic text-gray-500">
-          Last edited by {internalReview.lastAdminEditBy} on{' '}
+          Last admin scoring by {internalReview.lastAdminEditBy} on{' '}
           {format(internalReview.lastAdminEditOn, dateFormatting)}
         </Text>
       )}

--- a/components/dialog/ReviewerScoringDialog.tsx
+++ b/components/dialog/ReviewerScoringDialog.tsx
@@ -45,7 +45,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data, readOnly }) =
     <Flex direction="column" gap="3">
       {internalReview?.lastReviewerEditOn && (
         <Text size="2" className="italic text-gray-500">
-          Last edited on {format(internalReview.lastReviewerEditOn, "dd/MM/yy 'at' HH:mm")}
+          Last reviewed on {format(internalReview.lastReviewerEditOn, "dd/MM/yy 'at' HH:mm")}
         </Text>
       )}
 

--- a/components/dialog/ReviewerScoringDialog.tsx
+++ b/components/dialog/ReviewerScoringDialog.tsx
@@ -5,6 +5,7 @@ import FormWrapper from '@/components/dialog/FormWrapper'
 import GenericDialog from '@/components/dialog/GenericDialog'
 import LabelText from '@/components/general/LabelText'
 import { reviewerAccess } from '@/lib/access'
+import { dateFormatting } from '@/lib/constants'
 import { upsertReviewerScoring } from '@/lib/query/forms'
 import { FormPassbackState } from '@/lib/types'
 import { ord } from '@/lib/utils'
@@ -45,7 +46,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data, readOnly }) =
     <Flex direction="column" gap="3">
       {internalReview?.lastReviewerEditOn && (
         <Text size="2" className="italic text-gray-500">
-          Last reviewed on {format(internalReview.lastReviewerEditOn, "dd/MM/yy 'at' HH:mm")}
+          Last reviewed on {format(internalReview.lastReviewerEditOn, dateFormatting)}
         </Text>
       )}
 

--- a/components/dialog/ReviewerScoringDialog.tsx
+++ b/components/dialog/ReviewerScoringDialog.tsx
@@ -142,7 +142,7 @@ const ReviewerScoringDialog: FC<ReviewerScoringDialogProps> = ({ data, userEmail
   const handleFormSuccess = () => setIsOpen(false)
 
   const upsertReviewerScoringWithId = (prevState: FormPassbackState, formData: FormData) =>
-    upsertReviewerScoring(data.id, prevState, formData)
+    upsertReviewerScoring(data.id, userEmail, prevState, formData)
 
   const readOnly = !reviewerAccess(data.reviewer?.login, userEmail)
 

--- a/components/dialog/UgTutorDialog.tsx
+++ b/components/dialog/UgTutorDialog.tsx
@@ -32,6 +32,7 @@ import {
   TextArea,
   TextField
 } from '@radix-ui/themes'
+import { format } from 'date-fns'
 import React, { FC, useEffect, useMemo, useState } from 'react'
 
 type Tab = 'outcomes' | 'comments'
@@ -86,6 +87,13 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
 
   return (
     <Flex direction="column" gap="3">
+      {internalReview?.lastUserEditOn && internalReview?.lastUserEditBy && (
+        <Text size="2" className="italic text-gray-500">
+          Last edited by {internalReview.lastUserEditBy} on{' '}
+          {format(internalReview.lastUserEditOn, "dd/MM/yy 'at' HH:mm")}
+        </Text>
+      )}
+
       <CandidateCallout
         firstName={applicant.firstName}
         surname={applicant.surname}

--- a/components/dialog/UgTutorDialog.tsx
+++ b/components/dialog/UgTutorDialog.tsx
@@ -90,7 +90,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
     <Flex direction="column" gap="3">
       {internalReview?.lastUserEditOn && internalReview?.lastUserEditBy && (
         <Text size="2" className="italic text-gray-500">
-          Last edited by {internalReview.lastUserEditBy} on{' '}
+          Last overall edit by {internalReview.lastUserEditBy} on{' '}
           {format(internalReview.lastUserEditOn, dateFormatting)}
         </Text>
       )}

--- a/components/dialog/UgTutorDialog.tsx
+++ b/components/dialog/UgTutorDialog.tsx
@@ -233,6 +233,7 @@ const UgTutorDialog: FC<UgTutorDialogProps> = ({ data, reviewerLogin, user }) =>
   const upsertOutcomeWithId = async (prevState: FormPassbackState, formData: FormData) => {
     return await updateOutcomes(
       id,
+      email,
       data.outcomes.map((o) => ({
         id: o.id,
         degreeCode: o.degreeCode

--- a/components/dialog/UgTutorDialog.tsx
+++ b/components/dialog/UgTutorDialog.tsx
@@ -9,6 +9,7 @@ import Dropdown from '@/components/general/Dropdown'
 import LabelText from '@/components/general/LabelText'
 import { ApplicationRow } from '@/components/table/ApplicationTable'
 import { adminAccess } from '@/lib/access'
+import { dateFormatting } from '@/lib/constants'
 import { insertComment, updateOutcomes } from '@/lib/query/forms'
 import { FormPassbackState } from '@/lib/types'
 import { decimalToNumber } from '@/lib/utils'
@@ -90,7 +91,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
       {internalReview?.lastUserEditOn && internalReview?.lastUserEditBy && (
         <Text size="2" className="italic text-gray-500">
           Last edited by {internalReview.lastUserEditBy} on{' '}
-          {format(internalReview.lastUserEditOn, "dd/MM/yy 'at' HH:mm")}
+          {format(internalReview.lastUserEditOn, dateFormatting)}
         </Text>
       )}
 

--- a/components/table/ApplicationTable.tsx
+++ b/components/table/ApplicationTable.tsx
@@ -140,7 +140,11 @@ const ApplicationTable: FC<ApplicationTableProps> = ({
       }),
       columnHelper.accessor('nextAction', {
         cell: (info) => (
-          <NextActionCell nextAction={info.getValue()} applicationId={info.row.original.id} />
+          <NextActionCell
+            userEmail={email}
+            nextAction={info.getValue()}
+            applicationId={info.row.original.id}
+          />
         ),
         header: 'Next Action',
         id: SEARCH_PARAM_NEXT_ACTION
@@ -258,9 +262,10 @@ const WPColourMap: Record<WP, 'green' | 'red' | 'yellow'> = {
   [WP.NOT_CALCULATED]: 'yellow'
 }
 
-const NextActionCell: FC<{ nextAction: NextAction; applicationId: number }> = ({
+const NextActionCell: FC<{ nextAction: NextAction; applicationId: number; userEmail: string }> = ({
   nextAction,
-  applicationId
+  applicationId,
+  userEmail
 }) => {
   return (
     <Flex align="center" justify="between" gap="2">
@@ -271,6 +276,7 @@ const NextActionCell: FC<{ nextAction: NextAction; applicationId: number }> = ({
           color="grass"
           onClick={async () => {
             await updateNextAction(
+              userEmail,
               nextAction === NextAction.INFORM_CANDIDATE
                 ? NextAction.FINAL_CHECK
                 : NextAction.CANDIDATE_INFORMED,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+export const dateFormatting = "dd/MM/yy 'at' HH:mm"

--- a/lib/csv/upload.ts
+++ b/lib/csv/upload.ts
@@ -211,7 +211,9 @@ function updateAdminScoring(
             extracurricularAdminScore: a.extracurricularAdminScore,
             examComments: a.examComments,
             lastAdminEditBy: userEmail,
-            lastAdminEditOn: new Date()
+            lastAdminEditOn: new Date(),
+            lastUserEditBy: userEmail,
+            lastUserEditOn: new Date()
           }
         }
       }

--- a/lib/csv/upload.ts
+++ b/lib/csv/upload.ts
@@ -192,6 +192,7 @@ function updateAdminScoring(
     if (currentNextAction === NextAction.ADMIN_SCORING_WITH_TMUA)
       nextNextAction = NextAction.REVIEWER_SCORING
 
+    const currentTimestamp = new Date()
     return prisma.application.update({
       where: {
         admissionsCycle_cid: {
@@ -211,9 +212,9 @@ function updateAdminScoring(
             extracurricularAdminScore: a.extracurricularAdminScore,
             examComments: a.examComments,
             lastAdminEditBy: userEmail,
-            lastAdminEditOn: new Date(),
+            lastAdminEditOn: currentTimestamp,
             lastUserEditBy: userEmail,
-            lastUserEditOn: new Date()
+            lastUserEditOn: currentTimestamp
           }
         }
       }

--- a/lib/query/forms.ts
+++ b/lib/query/forms.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import prisma from '@/db'
+import { getUserFromCycleAndEmail } from '@/lib/query/users'
 import {
   formAdminSchema,
   formCommentSchema,
@@ -60,14 +61,18 @@ export async function upsertAdminScoring(
       extracurricularAdminScore,
       examComments,
       lastAdminEditBy: adminLogin,
-      lastAdminEditOn: new Date()
+      lastAdminEditOn: new Date(),
+      lastUserEditBy: adminLogin,
+      lastUserEditOn: new Date()
     },
     update: {
       motivationAdminScore,
       extracurricularAdminScore,
       examComments,
       lastAdminEditBy: adminLogin,
-      lastAdminEditOn: new Date()
+      lastAdminEditOn: new Date(),
+      lastUserEditBy: adminLogin,
+      lastUserEditOn: new Date()
     }
   })
 
@@ -77,6 +82,7 @@ export async function upsertAdminScoring(
 
 export async function upsertReviewerScoring(
   applicationId: number,
+  userEmail: string,
   _: FormPassbackState,
   formData: FormData
 ): Promise<FormPassbackState> {
@@ -104,7 +110,9 @@ export async function upsertReviewerScoring(
       extracurricularReviewerScore,
       referenceReviewerScore,
       academicComments,
-      lastReviewerEditOn: new Date()
+      lastReviewerEditOn: new Date(),
+      lastUserEditBy: userEmail,
+      lastUserEditOn: new Date()
     }
   })
 

--- a/lib/query/forms.ts
+++ b/lib/query/forms.ts
@@ -51,6 +51,7 @@ export async function upsertAdminScoring(
     }
   })
 
+  const currentTimestamp = new Date()
   await prisma.internalReview.upsert({
     where: {
       applicationId
@@ -61,18 +62,18 @@ export async function upsertAdminScoring(
       extracurricularAdminScore,
       examComments,
       lastAdminEditBy: adminLogin,
-      lastAdminEditOn: new Date(),
+      lastAdminEditOn: currentTimestamp,
       lastUserEditBy: adminLogin,
-      lastUserEditOn: new Date()
+      lastUserEditOn: currentTimestamp
     },
     update: {
       motivationAdminScore,
       extracurricularAdminScore,
       examComments,
       lastAdminEditBy: adminLogin,
-      lastAdminEditOn: new Date(),
+      lastAdminEditOn: currentTimestamp,
       lastUserEditBy: adminLogin,
-      lastUserEditOn: new Date()
+      lastUserEditOn: currentTimestamp
     }
   })
 
@@ -103,6 +104,7 @@ export async function upsertReviewerScoring(
     }
   })
 
+  const currentTimestamp = new Date()
   await prisma.internalReview.update({
     where: { applicationId },
     data: {
@@ -110,9 +112,9 @@ export async function upsertReviewerScoring(
       extracurricularReviewerScore,
       referenceReviewerScore,
       academicComments,
-      lastReviewerEditOn: new Date(),
+      lastReviewerEditOn: currentTimestamp,
       lastUserEditBy: userEmail,
-      lastUserEditOn: new Date()
+      lastUserEditOn: currentTimestamp
     }
   })
 

--- a/prisma/migrations/20250120134919_add_attributes_to_track_last_edit_on_application/migration.sql
+++ b/prisma/migrations/20250120134919_add_attributes_to_track_last_edit_on_application/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "InternalReview" ADD COLUMN     "lastUserEditBy" TEXT,
+ADD COLUMN     "lastUserEditOn" TIMESTAMP(3);

--- a/prisma/schema/application.prisma
+++ b/prisma/schema/application.prisma
@@ -78,6 +78,8 @@ model InternalReview {
   examComments                 String?
   lastAdminEditBy              String?
   lastAdminEditOn              DateTime?
+  lastUserEditBy               String?
+  lastUserEditOn               DateTime?
   motivationReviewerScore      Decimal?    @db.Decimal(3, 1)
   extracurricularReviewerScore Decimal?    @db.Decimal(3, 1)
   referenceReviewerScore       Decimal?    @db.Decimal(3, 1)


### PR DESCRIPTION
We've added the message "Last edited by .... on ...." on the top of UG tutor form.
For that, lastUserEditBy and lastUserEditOn were added to InternalReview.

 
![image](https://github.com/user-attachments/assets/bc683586-255d-4d93-9a7a-1c0dd2d51f98)

