### PR TITLE
feat: dialog style improvements and UG tutor button colours

### DIFF
--- a/components/dialog/AdminScoringDialog.tsx
+++ b/components/dialog/AdminScoringDialog.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import CandidateCallout from '@/components/dialog/CandidateCallout'
 import FormWrapper from '@/components/dialog/FormWrapper'
 import GenericDialog from '@/components/dialog/GenericDialog'
+import KeyCandidateInformation from '@/components/dialog/KeyCandidateInformation'
 import TmuaGradeBox from '@/components/dialog/TmuaGradeBox'
 import Dropdown from '@/components/general/Dropdown'
 import LabelText from '@/components/general/LabelText'
@@ -47,7 +47,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
         </Text>
       )}
 
-      <CandidateCallout
+      <KeyCandidateInformation
         firstName={applicant.firstName}
         surname={applicant.surname}
         ucasNumber={applicant.ucasNumber}

--- a/components/dialog/AdminScoringDialog.tsx
+++ b/components/dialog/AdminScoringDialog.tsx
@@ -10,7 +10,7 @@ import { adminAccess } from '@/lib/access'
 import { dateFormatting } from '@/lib/constants'
 import { upsertAdminScoring } from '@/lib/query/forms'
 import { FormPassbackState } from '@/lib/types'
-import { decimalToNumber } from '@/lib/utils'
+import { decimalToNumber, shortenEmail } from '@/lib/utils'
 import { AlevelQualification, GCSEQualification, Role } from '@prisma/client'
 import { IdCardIcon } from '@radix-ui/react-icons'
 import { Button, Flex, Heading, Popover, Text, TextField } from '@radix-ui/themes'
@@ -42,7 +42,7 @@ const AdminScoringForm: FC<AdminScoringFormProps> = ({ data, readOnly }) => {
     <Flex direction="column" gap="3">
       {internalReview?.lastAdminEditOn && internalReview?.lastAdminEditBy && (
         <Text size="2" className="italic text-gray-500">
-          Last admin scoring by {internalReview.lastAdminEditBy} on{' '}
+          Last admin scoring by {shortenEmail(internalReview.lastAdminEditBy)} on{' '}
           {format(internalReview.lastAdminEditOn, dateFormatting)}
         </Text>
       )}

--- a/components/dialog/AllComments.tsx
+++ b/components/dialog/AllComments.tsx
@@ -1,3 +1,4 @@
+import { shortenEmail } from '@/lib/utils'
 import { Comment as ApplicationComment, CommentType } from '@prisma/client'
 import { Badge, Card, Flex, Text } from '@radix-ui/themes'
 import { format } from 'date-fns'
@@ -21,7 +22,7 @@ const CommentItem: FC<CommentItemProps> = ({ comment }) => {
         {CommentTypeBadgeMap[comment.type]}
         <Flex gap="3" align="center">
           <Text weight="medium" size="3" className="ml-1">
-            {comment.authorLogin}
+            {shortenEmail(comment.authorLogin)}
           </Text>{' '}
           <Text size="2" color="gray">
             {format(new Date(comment.madeOn), 'HH:mm dd/MM/yyyy')}

--- a/components/dialog/CandidateCallout.tsx
+++ b/components/dialog/CandidateCallout.tsx
@@ -1,5 +1,5 @@
 import { shortenEmail } from '@/lib/utils'
-import { Callout, DataList, Flex } from '@radix-ui/themes'
+import { Card, DataList, Flex, Text } from '@radix-ui/themes'
 import React, { FC } from 'react'
 
 interface CandidateCalloutProps {
@@ -24,28 +24,32 @@ const CandidateCallout: FC<CandidateCalloutProps> = ({
   academicComments
 }) => {
   return (
-    <Callout.Root>
-      <Flex align="center" gap="9">
-        <DataList.Root>
-          <ListItem label="Applicant" value={`${firstName} ${surname}`} />
-          <ListItem label="UCAS number" value={ucasNumber} />
-          <ListItem label="Reviewer" value={reviewer ? shortenEmail(reviewer) : 'Unassigned'} />
-        </DataList.Root>
-        {showExtraInformation && (
+    <Card className="bg-blue-200">
+      <Flex>
+        <Flex flexBasis={showExtraInformation ? '40%' : '100%'}>
           <DataList.Root>
-            <ListItem
-              label="Reviewer percentile"
-              value={reviewerPercentile ? reviewerPercentile.toString() : 'N/A'}
-            />
-            <ListItem
-              label="Overall score"
-              value={overallScore ? overallScore.toString() : 'N/A'}
-            />
-            <ListItem label="Academic comments" value={academicComments || 'N/A'} />
+            <ListItem label="Applicant" value={`${firstName} ${surname}`} />
+            <ListItem label="UCAS number" value={ucasNumber} />
+            <ListItem label="Reviewer" value={reviewer ? shortenEmail(reviewer) : 'Unassigned'} />
           </DataList.Root>
+        </Flex>
+        {showExtraInformation && (
+          <Flex flexBasis="60%">
+            <DataList.Root>
+              <ListItem
+                label="Reviewer percentile"
+                value={reviewerPercentile ? reviewerPercentile.toString() : 'N/A'}
+              />
+              <ListItem
+                label="Overall score"
+                value={overallScore ? overallScore.toString() : 'N/A'}
+              />
+              <ListItem label="Academic comments" value={academicComments || 'N/A'} />
+            </DataList.Root>
+          </Flex>
         )}
       </Flex>
-    </Callout.Root>
+    </Card>
   )
 }
 
@@ -57,8 +61,10 @@ interface ListItemProps {
 const ListItem: FC<ListItemProps> = ({ label, value }) => {
   return (
     <DataList.Item align="center">
-      <DataList.Label>{label}:</DataList.Label>
-      <DataList.Value className="font-bold">{value}</DataList.Value>
+      <DataList.Label>
+        <Text weight="bold">{label}:</Text>
+      </DataList.Label>
+      <DataList.Value>{value}</DataList.Value>
     </DataList.Item>
   )
 }

--- a/components/dialog/KeyCandidateInformation.tsx
+++ b/components/dialog/KeyCandidateInformation.tsx
@@ -2,7 +2,7 @@ import { shortenEmail } from '@/lib/utils'
 import { Card, DataList, Flex, Text } from '@radix-ui/themes'
 import React, { FC } from 'react'
 
-interface CandidateCalloutProps {
+interface KeyCandidateInformation {
   firstName: string
   surname: string
   ucasNumber: string
@@ -13,11 +13,11 @@ interface CandidateCalloutProps {
   academicComments?: string | null
 }
 
-const CandidateCallout: FC<CandidateCalloutProps> = ({
+const KeyCandidateInformation: FC<KeyCandidateInformation> = ({
   firstName,
   surname,
   ucasNumber,
-  showExtraInformation = false,
+  showExtraInformation,
   reviewer,
   overallScore,
   reviewerPercentile,
@@ -69,4 +69,4 @@ const ListItem: FC<ListItemProps> = ({ label, value }) => {
   )
 }
 
-export default CandidateCallout
+export default KeyCandidateInformation

--- a/components/dialog/ReviewerScoringDialog.tsx
+++ b/components/dialog/ReviewerScoringDialog.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import CandidateCallout from '@/components/dialog/CandidateCallout'
 import FormWrapper from '@/components/dialog/FormWrapper'
 import GenericDialog from '@/components/dialog/GenericDialog'
+import KeyCandidateInformation from '@/components/dialog/KeyCandidateInformation'
 import LabelText from '@/components/general/LabelText'
 import { reviewerAccess } from '@/lib/access'
 import { dateFormatting } from '@/lib/constants'
@@ -50,7 +50,7 @@ const ReviewerScoringForm: FC<ReviewerScoringFormProps> = ({ data, readOnly }) =
         </Text>
       )}
 
-      <CandidateCallout
+      <KeyCandidateInformation
         firstName={applicant.firstName}
         surname={applicant.surname}
         ucasNumber={applicant.ucasNumber}

--- a/components/dialog/UgTutorDialog.tsx
+++ b/components/dialog/UgTutorDialog.tsx
@@ -12,7 +12,7 @@ import { adminAccess } from '@/lib/access'
 import { dateFormatting } from '@/lib/constants'
 import { insertComment, updateOutcomes } from '@/lib/query/forms'
 import { FormPassbackState } from '@/lib/types'
-import { decimalToNumber } from '@/lib/utils'
+import { decimalToNumber, shortenEmail } from '@/lib/utils'
 import {
   Comment as ApplicationComment,
   CommentType,
@@ -90,7 +90,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
     <Flex direction="column" gap="3">
       {internalReview?.lastUserEditOn && internalReview?.lastUserEditBy && (
         <Text size="2" className="italic text-gray-500">
-          Last overall edit by {internalReview.lastUserEditBy} on{' '}
+          Last overall edit by {shortenEmail(internalReview.lastUserEditBy)} on{' '}
           {format(internalReview.lastUserEditOn, dateFormatting)}
         </Text>
       )}

--- a/components/dialog/UgTutorDialog.tsx
+++ b/components/dialog/UgTutorDialog.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import AllComments from '@/components/dialog/AllComments'
-import CandidateCallout from '@/components/dialog/CandidateCallout'
 import FormWrapper from '@/components/dialog/FormWrapper'
 import GenericDialog from '@/components/dialog/GenericDialog'
+import KeyCandidateInformation from '@/components/dialog/KeyCandidateInformation'
 import TmuaGradeBox from '@/components/dialog/TmuaGradeBox'
 import Dropdown from '@/components/general/Dropdown'
 import LabelText from '@/components/general/LabelText'
@@ -95,7 +95,7 @@ const UgTutorForm: FC<UgTutorFormProps> = ({
         </Text>
       )}
 
-      <CandidateCallout
+      <KeyCandidateInformation
         firstName={applicant.firstName}
         surname={applicant.surname}
         ucasNumber={applicant.ucasNumber}

--- a/components/dialog/UgTutorDialog.tsx
+++ b/components/dialog/UgTutorDialog.tsx
@@ -257,7 +257,7 @@ const UgTutorDialog: FC<UgTutorDialogProps> = ({ data, reviewerLogin, user }) =>
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       trigger={
-        <Button className="min-h-10 w-20" color="ruby">
+        <Button className="min-h-10 w-20" color={decideTriggerColour(data)}>
           UG Tutor
         </Button>
       }
@@ -280,6 +280,31 @@ const UgTutorDialog: FC<UgTutorDialogProps> = ({ data, reviewerLogin, user }) =>
       </FormWrapper>
     </GenericDialog>
   )
+}
+
+/**
+ * Determines the trigger colour based on the application's outcomes.
+ * Orange if reviewer percentile set and ≤ 50, next action is UG_TUTOR_REVIEW and any decision pending
+ * Yellow if next action is UG_TUTOR_REVIEW and no pending decisions
+ * Bronze otherwise.
+ *
+ * @param {ApplicationRow} application - The application data.
+ * @returns {string} - Radix button colour.
+ */
+function decideTriggerColour(application: ApplicationRow): 'orange' | 'yellow' | 'bronze' {
+  const isOrange =
+    application.nextAction === NextAction.UG_TUTOR_REVIEW &&
+    application.internalReview?.reviewerPercentile &&
+    application.internalReview.reviewerPercentile <= 50 &&
+    application.outcomes.some((o) => o.decision === Decision.PENDING)
+  if (isOrange) return 'orange'
+
+  const isYellow =
+    application.nextAction === NextAction.UG_TUTOR_REVIEW &&
+    !application.outcomes.some((o) => o.decision === Decision.PENDING)
+  if (isYellow) return 'yellow'
+
+  return 'bronze'
 }
 
 export default UgTutorDialog


### PR DESCRIPTION
- UG Tutor colour changes according to the application and outcome (orange, yellow or bronze according to percentiles and decisions)
- Removing emails from edit log displays
- Use of `Card` and `Flex` with basis to handle large comments, `CandidateCallout` -> `KeyCandidateInformation` to reflect the component better
